### PR TITLE
feat: implementar servicio de operaciones SIAT e integración de logs

### DIFF
--- a/internal/adapter/service/siat/siat_operaciones_service.go
+++ b/internal/adapter/service/siat/siat_operaciones_service.go
@@ -1,0 +1,216 @@
+package siat
+
+import (
+	"context"
+	"fmt"
+	"go-siat/internal/core/domain/datatype/soap"
+	"go-siat/internal/core/domain/facturacion"
+	"go-siat/internal/core/domain/facturacion/operaciones"
+	"go-siat/internal/core/port"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v3/client"
+)
+
+type SiatOperacionesService struct {
+	Url        string
+	HttpClient *client.Client
+}
+
+// ConsultaPuntoVenta implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) ConsultaPuntoVenta(ctx context.Context, config facturacion.Config, req *operaciones.ConsultaPuntoVenta) (*soap.EnvelopeResponse[operaciones.ConsultaPuntoVentaResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	// Ejecutar la petición HTTP utilizando el cliente configurado
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.ConsultaPuntoVentaResponse](resp)
+}
+
+// CierreOperacionesSistema implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) CierreOperacionesSistema(ctx context.Context, config facturacion.Config, req *operaciones.CierreOperacionesSistema) (*soap.EnvelopeResponse[operaciones.CierreOperacionesSistemaResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	// Ejecutar la petición HTTP utilizando el cliente configurado
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.CierreOperacionesSistemaResponse](resp)
+}
+
+// CierrePuntoVenta implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) CierrePuntoVenta(ctx context.Context, config facturacion.Config, req *operaciones.CierrePuntoVenta) (*soap.EnvelopeResponse[operaciones.CierrePuntoVentaResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.CierrePuntoVentaResponse](resp)
+}
+
+// ConsultaEventosSignificativos implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) ConsultaEventosSignificativos(ctx context.Context, config facturacion.Config, req *operaciones.ConsultaEventoSignificativo) (*soap.EnvelopeResponse[operaciones.ConsultaEventoSignificativoResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	// Ejecutar la petición HTTP utilizando el cliente configurado
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.ConsultaEventoSignificativoResponse](resp)
+}
+
+// RegistroEventosSignificativos implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) RegistroEventosSignificativos(ctx context.Context, config facturacion.Config, req *operaciones.RegistroEventoSignificativo) (*soap.EnvelopeResponse[operaciones.RegistroEventoSignificativoResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	// Ejecutar la petición HTTP utilizando el cliente configurado
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.RegistroEventoSignificativoResponse](resp)
+}
+
+// VerificarComunicacion implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) VerificarComunicacion(ctx context.Context, config facturacion.Config) (*soap.EnvelopeResponse[operaciones.VerificarComunicacionResponse], error) {
+	req := operaciones.VerificarComunicacion{}
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.VerificarComunicacionResponse](resp)
+}
+
+// RegistroPuntoVenta implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) RegistroPuntoVenta(ctx context.Context, config facturacion.Config, req *operaciones.RegistroPuntoVenta) (*soap.EnvelopeResponse[operaciones.RegistroPuntoVentaResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	// Ejecutar la petición HTTP utilizando el cliente configurado
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+
+	return parseSoapResponse[operaciones.RegistroPuntoVentaResponse](resp)
+}
+
+// RegistroPuntoVentaComisionista implements [port.SiatOperacionesPort].
+func (s *SiatOperacionesService) RegistroPuntoVentaComisionista(ctx context.Context, config facturacion.Config, req *operaciones.RegistroPuntoVentaComisionista) (*soap.EnvelopeResponse[operaciones.RegistroPuntoVentaComisionistaResponse], error) {
+	xmlBody, err := buildRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ejecutar la petición HTTP utilizando el cliente configurado
+	resp, err := s.HttpClient.Post(fullURLOperaciones(s.Url), client.Config{
+		Ctx:  ctx,
+		Body: xmlBody,
+		Header: map[string]string{
+			"Content-Type": "application/xml",
+			"apiKey":       fmt.Sprintf("TokenApi %s", config.Token),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error al hacer request HTTP: %w", err)
+	}
+	return parseSoapResponse[operaciones.RegistroPuntoVentaComisionistaResponse](resp)
+}
+
+func NewSiatOperacionesService(url string, httpClient *client.Client) (*SiatOperacionesService, error) {
+	cleanUrl := strings.TrimSpace(url)
+	if cleanUrl == "" {
+		return nil, fmt.Errorf("la URL base del SIAT no puede estar vacía")
+	}
+
+	// Si no se inyecta un cliente, creamos uno con configuraciones seguras por defecto
+	if httpClient == nil {
+		httpClient = client.New()
+		httpClient.SetTimeout(15 * time.Second)
+	}
+
+	return &SiatOperacionesService{
+		Url:        cleanUrl,
+		HttpClient: httpClient,
+	}, nil
+}
+
+var _ port.SiatOperacionesPort = (*SiatOperacionesService)(nil)

--- a/internal/adapter/service/siat/siat_operaciones_service_test.go
+++ b/internal/adapter/service/siat/siat_operaciones_service_test.go
@@ -1,0 +1,302 @@
+package siat_test
+
+import (
+	"context"
+	"encoding/xml"
+	"go-siat/internal/adapter/service/siat"
+	"go-siat/internal/core/domain/facturacion"
+	"go-siat/internal/core/domain/facturacion/operaciones"
+	"go-siat/internal/core/util"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistroPuntoVenta(t *testing.T) {
+	godotenv.Load()
+
+	nit, err := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	if err != nil {
+		t.Fatalf("la variable SIAT_NIT debe ser un número válido: %v", err)
+	}
+	codAmbiente, err := util.ParseIntSafe(os.Getenv("SIAT_CODIGO_AMBIENTE"))
+	if err != nil {
+		t.Fatalf("la variable SIAT_CODIGO_AMBIENTE debe ser un número válido: %v", err)
+	}
+	codModalidad, err := util.ParseIntSafe(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+	if err != nil {
+		t.Fatalf("la variable SIAT_CODIGO_MODALIDAD debe ser un número válido: %v", err)
+	}
+
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+
+	service, err := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+	if err != nil {
+		t.Fatalf("No se pudo inicializar el servicio de operaciones: %v", err)
+	}
+
+	req := &operaciones.RegistroPuntoVenta{
+		SolicitudRegistroPuntoVenta: operaciones.SolicitudRegistroPuntoVenta{
+			CodigoAmbiente:       codAmbiente,
+			CodigoModalidad:      codModalidad,
+			CodigoSistema:        os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal:       0,
+			CodigoTipoPuntoVenta: 2, // Tipo de punto de venta (2,3,4,5,6)
+			Cuis:                 "197C8240",
+			Descripcion:          "Punto de Venta Prueba 1",
+			Nit:                  nit,
+			NombrePuntoVenta:     "PV1",
+		},
+	}
+
+	resp, err := service.RegistroPuntoVenta(context.Background(), config, req)
+
+	if !assert.NoError(t, err) {
+		t.Fatalf("Fallo en la comunicación con el SIAT: %v", err)
+	}
+	xmlBody, err := xml.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		log.Printf("Error al convertir a XML: %v", err)
+	}
+	log.Printf("Respuesta: %s", string(xmlBody))
+	if assert.NotNil(t, resp) {
+		resultado := resp.Body.Content.Respuesta
+		log.Printf("Resultado Registro Punto Venta - Transacción: %v", resultado.Transaccion)
+		if resultado.Transaccion {
+			log.Printf("Código Punto Venta: %d", resultado.CodigoPuntoVenta)
+		}
+		for _, msg := range resultado.MensajesList {
+			log.Printf("Mensaje SIAT [%d]: %s", msg.Codigo, msg.Descripcion)
+		}
+	}
+}
+
+func TestRegistroPuntoVentaComisionista(t *testing.T) {
+	godotenv.Load()
+
+	nit, err := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	if err != nil {
+		t.Fatalf("la variable SIAT_NIT debe ser un número válido: %v", err)
+	}
+	codAmbiente, err := util.ParseIntSafe(os.Getenv("SIAT_CODIGO_AMBIENTE"))
+	if err != nil {
+		t.Fatalf("la variable SIAT_CODIGO_AMBIENTE debe ser un número válido: %v", err)
+	}
+	codModalidad, err := util.ParseIntSafe(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+	if err != nil {
+		t.Fatalf("la variable SIAT_CODIGO_MODALIDAD debe ser un número válido: %v", err)
+	}
+
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+
+	service, err := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+	if err != nil {
+		t.Fatalf("No se pudo inicializar el servicio de operaciones: %v", err)
+	}
+
+	now := time.Now()
+	req := &operaciones.RegistroPuntoVentaComisionista{
+		SolicitudPuntoVentaComisionista: operaciones.SolicitudPuntoVentaComisionista{
+			CodigoAmbiente:   codAmbiente,
+			CodigoModalidad:  codModalidad,
+			CodigoSistema:    os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal:   0,
+			Cuis:             "197C8240",
+			Descripcion:      "Comisionista Prueba SIAT",
+			FechaInicio:      now,
+			FechaFin:         now.Add(24 * time.Hour),
+			Nit:              nit,
+			NitComisionista:  425951025, // Reemplazar por un NIT comisionista válido si es necesario
+			NombrePuntoVenta: "COM-SIAT",
+			NumeroContrato:   "CONT-001",
+		},
+	}
+
+	resp, err := service.RegistroPuntoVentaComisionista(context.Background(), config, req)
+
+	if err != nil {
+		log.Printf("Error/Soap Fault en RegistroPuntoVentaComisionista: %v", err)
+		t.Errorf("Error en RegistroPuntoVentaComisionista: %v", err)
+	}
+
+	if resp != nil {
+		resultado := resp.Body.Content.Respuesta
+		log.Printf("Resultado Registro Comisionista - Transacción: %v", resultado.Transaccion)
+		for _, msg := range resultado.MensajesList {
+			log.Printf("Mensaje SIAT [%d]: %s", msg.Codigo, msg.Descripcion)
+		}
+	}
+}
+
+func TestOperacionesVerificarComunicacion(t *testing.T) {
+	godotenv.Load()
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+	service, _ := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+
+	resp, err := service.VerificarComunicacion(context.Background(), config)
+
+	if assert.NoError(t, err) && assert.NotNil(t, resp) {
+		log.Printf("Respuesta: %v", resp)
+		log.Printf("Resultado VerificarComunicacion: %v", resp.Body.Content.Return.Transaccion)
+		assert.True(t, resp.Body.Content.Return.Transaccion)
+	}
+}
+
+func TestConsultaPuntoVenta(t *testing.T) {
+	godotenv.Load()
+	nit, _ := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+	service, _ := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+
+	req := &operaciones.ConsultaPuntoVenta{
+		SolicitudConsultaPuntoVenta: operaciones.SolicitudConsultaPuntoVenta{
+			CodigoAmbiente: 2,
+			CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal: 0,
+			Cuis:           "197C8240",
+			Nit:            nit,
+		},
+	}
+
+	resp, err := service.ConsultaPuntoVenta(context.Background(), config, req)
+
+	if assert.NoError(t, err) && assert.NotNil(t, resp) {
+		res := resp.Body.Content.Respuesta
+		log.Printf("Puntos de Venta encontrados: %d", len(res.ListaPuntosVentas))
+		for _, pv := range res.ListaPuntosVentas {
+			log.Printf("PV: %s (Código: %d)", pv.NombrePuntoVenta, pv.CodigoPuntoVenta)
+		}
+	}
+}
+
+func TestCierrePuntoVenta(t *testing.T) {
+	godotenv.Load()
+	nit, _ := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+	service, _ := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+
+	req := &operaciones.CierrePuntoVenta{
+		SolicitudCierrePuntoVenta: operaciones.SolicitudCierrePuntoVenta{
+			CodigoAmbiente:   2,
+			CodigoPuntoVenta: 13, // Un código que probablemente no exista o sea de prueba
+			CodigoSistema:    os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal:   0,
+			Cuis:             "197C8240",
+			Nit:              nit,
+		},
+	}
+
+	resp, err := service.CierrePuntoVenta(context.Background(), config, req)
+
+	if err == nil && resp != nil {
+		log.Printf("Resultado Cierre PV: %v", resp.Body.Content.Respuesta.Transaccion)
+	} else {
+		log.Printf("Cierre PV finalizado con (posible error de negocio): %v", err)
+	}
+}
+
+func TestCierreOperacionesSistema(t *testing.T) {
+	godotenv.Load()
+	nit, _ := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+	service, _ := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+
+	req := &operaciones.CierreOperacionesSistema{
+		SolicitudOperaciones: operaciones.SolicitudOperaciones{
+			CodigoAmbiente:   2,
+			CodigoSistema:    os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal:   0,
+			Cuis:             "E97E7A16",
+			Nit:              nit,
+			CodigoModalidad:  1,
+			CodigoPuntoVenta: 1,
+		},
+	}
+
+	resp, err := service.CierreOperacionesSistema(context.Background(), config, req)
+
+	if err == nil && resp != nil {
+		log.Printf("Resultado Cierre Sistema: %v", resp.Body.Content.Respuesta)
+	} else {
+		log.Printf("Cierre Sistema finalizado con: %v", err)
+	}
+}
+
+func TestRegistroEventosSignificativos(t *testing.T) {
+	godotenv.Load()
+	nit, _ := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+	service, _ := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+
+	now := time.Now()
+	req := &operaciones.RegistroEventoSignificativo{
+		SolicitudEventoSignificativo: operaciones.SolicitudEventoSignificativo{
+			CodigoAmbiente:        2,
+			CodigoMotivoEvento:    4,
+			CodigoSistema:         os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal:        0,
+			Cuis:                  "197C8240",
+			CufdEvento:            "FBQT5...",
+			Cufd:                  "FBQT5...",
+			Descripcion:           "Prueba de evento significativo",
+			FechaHoraInicioEvento: now.Add(-1 * time.Hour),
+			FechaHoraFinEvento:    now,
+			Nit:                   nit,
+			CodigoPuntoVenta:      0,
+		},
+	}
+
+	resp, err := service.RegistroEventosSignificativos(context.Background(), config, req)
+
+	if err == nil && resp != nil {
+		log.Printf("Resultado Registro Evento: %v", resp.Body.Content)
+	} else {
+		log.Printf("Registro Evento finalizado con: %v", err)
+	}
+}
+
+func TestConsultaEventosSignificativos(t *testing.T) {
+	godotenv.Load()
+	nit, _ := util.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	config := facturacion.Config{
+		Token: os.Getenv("SIAT_TOKEN"),
+	}
+	service, _ := siat.NewSiatOperacionesService(os.Getenv("SIAT_URL"), nil)
+
+	req := &operaciones.ConsultaEventoSignificativo{
+		SolicitudConsultaEvento: operaciones.SolicitudConsultaEvento{
+			CodigoAmbiente:   2,
+			CodigoSistema:    os.Getenv("SIAT_CODIGO_SISTEMA"),
+			CodigoSucursal:   0,
+			Cuis:             "197C8240",
+			Nit:              nit,
+			FechaEvento:      time.Now(),
+			CodigoPuntoVenta: 0,
+		},
+	}
+
+	resp, err := service.ConsultaEventosSignificativos(context.Background(), config, req)
+
+	if assert.NoError(t, err) && assert.NotNil(t, resp) {
+		res := resp.Body.Content.Respuesta
+		log.Printf("Eventos encontrados: %d", len(res.ListaCodigos))
+	}
+}

--- a/internal/core/domain/facturacion/operaciones/eventos_significativo.go
+++ b/internal/core/domain/facturacion/operaciones/eventos_significativo.go
@@ -1,0 +1,72 @@
+package operaciones
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+// RegistroEventoSignificativo es el wrapper para registrar un evento
+type RegistroEventoSignificativo struct {
+	XMLName                      xml.Name                     `xml:"ns:registroEventoSignificativo"`
+	SolicitudEventoSignificativo SolicitudEventoSignificativo `xml:"SolicitudEventoSignificativo"`
+}
+
+// SolicitudEventoSignificativo representa los datos para registrar un evento
+type SolicitudEventoSignificativo struct {
+	CodigoAmbiente        int       `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoMotivoEvento    int       `xml:"codigoMotivoEvento" json:"codigoMotivoEvento"`
+	CodigoPuntoVenta      int       `xml:"codigoPuntoVenta,omitempty" json:"codigoPuntoVenta,omitempty"`
+	CodigoSistema         string    `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal        int       `xml:"codigoSucursal" json:"codigoSucursal"`
+	Cufd                  string    `xml:"cufd" json:"cufd"`
+	CufdEvento            string    `xml:"cufdEvento" json:"cufdEvento"`
+	Cuis                  string    `xml:"cuis" json:"cuis"`
+	Descripcion           string    `xml:"descripcion" json:"descripcion"`
+	FechaHoraFinEvento    time.Time `xml:"fechaHoraFinEvento" json:"fechaHoraFinEvento"`
+	FechaHoraInicioEvento time.Time `xml:"fechaHoraInicioEvento" json:"fechaHoraInicioEvento"`
+	Nit                   int64     `xml:"nit" json:"nit"`
+}
+
+// RegistroEventoSignificativoResponse es el wrapper para la respuesta de registro de evento
+type RegistroEventoSignificativoResponse struct {
+	Respuesta RespuestaListaEventos `xml:"RespuestaListaEventos"`
+}
+
+// RespuestaListaEventos representa el resultado de registro/consulta de eventos
+type RespuestaListaEventos struct {
+	CodigoRecepcionEventoSignificativo int64                      `xml:"codigoRecepcionEventoSignificativo" json:"codigoRecepcionEventoSignificativo"`
+	ListaCodigos                       []EventosSignificativosDto `xml:"listaCodigos" json:"listaCodigos"`
+	MensajesList                       []MensajeServicio          `xml:"mensajesList" json:"mensajesList"`
+	Transaccion                        bool                       `xml:"transaccion" json:"transaccion"`
+}
+
+// EventosSignificativosDto representa la información de un evento significativo
+type EventosSignificativosDto struct {
+	CodigoEvento                       int    `xml:"codigoEvento" json:"codigoEvento"`
+	CodigoRecepcionEventoSignificativo int64  `xml:"codigoRecepcionEventoSignificativo" json:"codigoRecepcionEventoSignificativo"`
+	Descripcion                        string `xml:"descripcion" json:"descripcion"`
+	FechaFin                           string `xml:"fechaFin" json:"fechaFin"`
+	FechaInicio                        string `xml:"fechaInicio" json:"fechaInicio"`
+}
+
+// ConsultaEventoSignificativo es el wrapper para consultar eventos
+type ConsultaEventoSignificativo struct {
+	XMLName                 xml.Name                `xml:"ns:consultaEventoSignificativo"`
+	SolicitudConsultaEvento SolicitudConsultaEvento `xml:"SolicitudConsultaEvento"`
+}
+
+// SolicitudConsultaEvento representa los datos para consultar eventos
+type SolicitudConsultaEvento struct {
+	CodigoAmbiente   int       `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoPuntoVenta int       `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
+	CodigoSistema    string    `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal   int       `xml:"codigoSucursal" json:"codigoSucursal"`
+	Cuis             string    `xml:"cuis" json:"cuis"`
+	FechaEvento      time.Time `xml:"fechaEvento" json:"fechaEvento"`
+	Nit              int64     `xml:"nit" json:"nit"`
+}
+
+// ConsultaEventoSignificativoResponse es el wrapper para la respuesta de consulta de eventos
+type ConsultaEventoSignificativoResponse struct {
+	Respuesta RespuestaListaEventos `xml:"RespuestaListaEventos"`
+}

--- a/internal/core/domain/facturacion/operaciones/mensaje.go
+++ b/internal/core/domain/facturacion/operaciones/mensaje.go
@@ -1,0 +1,7 @@
+package operaciones
+
+// MensajeServicio representa un mensaje devuelto por el servidor del SIAT
+type MensajeServicio struct {
+	Codigo      int    `xml:"codigo" json:"codigo"`
+	Descripcion string `xml:"descripcion" json:"descripcion"`
+}

--- a/internal/core/domain/facturacion/operaciones/operaciones.go
+++ b/internal/core/domain/facturacion/operaciones/operaciones.go
@@ -1,0 +1,32 @@
+package operaciones
+
+import "encoding/xml"
+
+// CierreOperacionesSistema es el wrapper para cerrar operaciones del sistema
+type CierreOperacionesSistema struct {
+	XMLName              xml.Name             `xml:"ns:cierreOperacionesSistema"`
+	SolicitudOperaciones SolicitudOperaciones `xml:"SolicitudOperaciones"`
+}
+
+// SolicitudOperaciones es la base para las solicitudes de operaciones
+type SolicitudOperaciones struct {
+	CodigoAmbiente   int    `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoModalidad  int    `xml:"codigoModalidad" json:"codigoModalidad"`
+	CodigoPuntoVenta int    `xml:"codigoPuntoVenta,omitempty" json:"codigoPuntoVenta,omitempty"`
+	CodigoSistema    string `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal   int    `xml:"codigoSucursal" json:"codigoSucursal"`
+	Cuis             string `xml:"cuis" json:"cuis"`
+	Nit              int64  `xml:"nit" json:"nit"`
+}
+
+// CierreOperacionesSistemaResponse es el wrapper para la respuesta de cierre de sistema
+type CierreOperacionesSistemaResponse struct {
+	Respuesta RespuestaCierreSistemas `xml:"RespuestaCierreSistemas"`
+}
+
+// RespuestaCierreSistemas representa el resultado del cierre de operaciones
+type RespuestaCierreSistemas struct {
+	CodigoSistema string            `xml:"codigoSistema" json:"codigoSistema"`
+	MensajesList  []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+	Transaccion   bool              `xml:"transaccion" json:"transaccion"`
+}

--- a/internal/core/domain/facturacion/operaciones/puntos_venta.go
+++ b/internal/core/domain/facturacion/operaciones/puntos_venta.go
@@ -1,0 +1,133 @@
+package operaciones
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+// RegistroPuntoVenta es el wrapper para registrar un punto de venta
+type RegistroPuntoVenta struct {
+	XMLName                     xml.Name                    `xml:"ns:registroPuntoVenta"`
+	SolicitudRegistroPuntoVenta SolicitudRegistroPuntoVenta `xml:"SolicitudRegistroPuntoVenta"`
+}
+
+// SolicitudRegistroPuntoVenta representa los datos para registrar un punto de venta
+type SolicitudRegistroPuntoVenta struct {
+	CodigoAmbiente       int    `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoModalidad      int    `xml:"codigoModalidad" json:"codigoModalidad"`
+	CodigoSistema        string `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal       int    `xml:"codigoSucursal" json:"codigoSucursal"`
+	CodigoTipoPuntoVenta int    `xml:"codigoTipoPuntoVenta" json:"codigoTipoPuntoVenta"`
+	Cuis                 string `xml:"cuis" json:"cuis"`
+	Descripcion          string `xml:"descripcion" json:"descripcion"`
+	Nit                  int64  `xml:"nit" json:"nit"`
+	NombrePuntoVenta     string `xml:"nombrePuntoVenta" json:"nombrePuntoVenta"`
+}
+
+// RegistroPuntoVentaResponse es el wrapper para la respuesta de registro
+type RegistroPuntoVentaResponse struct {
+	Respuesta RespuestaRegistroPuntoVenta `xml:"RespuestaRegistroPuntoVenta"`
+}
+
+// RespuestaRegistroPuntoVenta representa el resultado del registro
+type RespuestaRegistroPuntoVenta struct {
+	CodigoPuntoVenta int               `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
+	MensajesList     []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+	Transaccion      bool              `xml:"transaccion" json:"transaccion"`
+}
+
+// ConsultaPuntoVenta es el wrapper para consultar puntos de venta
+type ConsultaPuntoVenta struct {
+	XMLName                     xml.Name                    `xml:"ns:consultaPuntoVenta"`
+	SolicitudConsultaPuntoVenta SolicitudConsultaPuntoVenta `xml:"SolicitudConsultaPuntoVenta"`
+}
+
+// SolicitudConsultaPuntoVenta representa los datos para consultar puntos de venta
+type SolicitudConsultaPuntoVenta struct {
+	CodigoAmbiente int    `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoSistema  string `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal int    `xml:"codigoSucursal" json:"codigoSucursal"`
+	Cuis           string `xml:"cuis" json:"cuis"`
+	Nit            int64  `xml:"nit" json:"nit"`
+}
+
+// ConsultaPuntoVentaResponse es el wrapper para la respuesta de consulta
+type ConsultaPuntoVentaResponse struct {
+	Respuesta RespuestaConsultaPuntoVenta `xml:"RespuestaConsultaPuntoVenta"`
+}
+
+// RespuestaConsultaPuntoVenta representa el resultado de la consulta
+type RespuestaConsultaPuntoVenta struct {
+	ListaPuntosVentas []PuntosVentasDto `xml:"listaPuntosVentas" json:"listaPuntosVentas"`
+	MensajesList      []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+	Transaccion       bool              `xml:"transaccion" json:"transaccion"`
+}
+
+// PuntosVentasDto representa la información de un punto de venta
+type PuntosVentasDto struct {
+	CodigoPuntoVenta int    `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
+	NombrePuntoVenta string `xml:"nombrePuntoVenta" json:"nombrePuntoVenta"`
+	TipoPuntoVenta   string `xml:"tipoPuntoVenta" json:"tipoPuntoVenta"`
+}
+
+// CierrePuntoVenta es el wrapper para cerrar un punto de venta
+type CierrePuntoVenta struct {
+	XMLName                   xml.Name                  `xml:"ns:cierrePuntoVenta"`
+	SolicitudCierrePuntoVenta SolicitudCierrePuntoVenta `xml:"SolicitudCierrePuntoVenta"`
+}
+
+// SolicitudCierrePuntoVenta representa los datos para cerrar un punto de venta
+type SolicitudCierrePuntoVenta struct {
+	CodigoAmbiente   int    `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoPuntoVenta int    `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
+	CodigoSistema    string `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal   int    `xml:"codigoSucursal" json:"codigoSucursal"`
+	Cuis             string `xml:"cuis" json:"cuis"`
+	Nit              int64  `xml:"nit" json:"nit"`
+}
+
+// CierrePuntoVentaResponse es el wrapper para la respuesta de cierre
+type CierrePuntoVentaResponse struct {
+	Respuesta RespuestaCierrePuntoVenta `xml:"RespuestaCierrePuntoVenta"`
+}
+
+// RespuestaCierrePuntoVenta representa el resultado del cierre
+type RespuestaCierrePuntoVenta struct {
+	CodigoPuntoVenta int               `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
+	MensajesList     []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+	Transaccion      bool              `xml:"transaccion" json:"transaccion"`
+}
+
+// RegistroPuntoVentaComisionista es el wrapper para registrar un comisionista
+type RegistroPuntoVentaComisionista struct {
+	XMLName                         xml.Name                        `xml:"ns:registroPuntoVentaComisionista"`
+	SolicitudPuntoVentaComisionista SolicitudPuntoVentaComisionista `xml:"SolicitudPuntoVentaComisionista"`
+}
+
+// SolicitudPuntoVentaComisionista representa los datos para registrar un comisionista
+type SolicitudPuntoVentaComisionista struct {
+	CodigoAmbiente   int       `xml:"codigoAmbiente" json:"codigoAmbiente"`
+	CodigoModalidad  int       `xml:"codigoModalidad" json:"codigoModalidad"`
+	CodigoSistema    string    `xml:"codigoSistema" json:"codigoSistema"`
+	CodigoSucursal   int       `xml:"codigoSucursal" json:"codigoSucursal"`
+	Cuis             string    `xml:"cuis" json:"cuis"`
+	Descripcion      string    `xml:"descripcion" json:"descripcion"`
+	FechaFin         time.Time `xml:"fechaFin" json:"fechaFin"`
+	FechaInicio      time.Time `xml:"fechaInicio" json:"fechaInicio"`
+	Nit              int64     `xml:"nit" json:"nit"`
+	NitComisionista  int64     `xml:"nitComisionista" json:"nitComisionista"`
+	NombrePuntoVenta string    `xml:"nombrePuntoVenta" json:"nombrePuntoVenta"`
+	NumeroContrato   string    `xml:"numeroContrato" json:"numeroContrato"`
+}
+
+// RegistroPuntoVentaComisionistaResponse es el wrapper para la respuesta de comisionista
+type RegistroPuntoVentaComisionistaResponse struct {
+	Respuesta RespuestaPuntoVentaComisionista `xml:"RespuestaPuntoVentaComisionista"`
+}
+
+// RespuestaPuntoVentaComisionista representa el resultado del registro de comisionista
+type RespuestaPuntoVentaComisionista struct {
+	CodigoPuntoVenta int               `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
+	MensajesList     []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+	Transaccion      bool              `xml:"transaccion" json:"transaccion"`
+}

--- a/internal/core/domain/facturacion/operaciones/verificar_comunicacion.go
+++ b/internal/core/domain/facturacion/operaciones/verificar_comunicacion.go
@@ -1,0 +1,23 @@
+package operaciones
+
+import (
+	"encoding/xml"
+)
+
+// VerificarComunicacion es el wrapper para la petición (Request)
+type VerificarComunicacion struct {
+	XMLName xml.Name `xml:"ns:verificarComunicacion"`
+}
+
+// VerificarComunicacionResponse representa el Body de la respuesta SOAP
+type VerificarComunicacionResponse struct {
+	XMLName xml.Name `xml:"verificarComunicacionResponse"`
+	// El SIAT siempre devuelve los datos dentro de un nodo <return>
+	Return RespuestaComunicacion `xml:"return"`
+}
+
+// RespuestaComunicacion representa la estructura interna de la respuesta
+type RespuestaComunicacion struct {
+	MensajesList []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+	Transaccion  bool              `xml:"transaccion" json:"transaccion"`
+}

--- a/internal/core/port/siat_operaciones_port.go
+++ b/internal/core/port/siat_operaciones_port.go
@@ -1,0 +1,19 @@
+package port
+
+import (
+	"context"
+	"go-siat/internal/core/domain/datatype/soap"
+	"go-siat/internal/core/domain/facturacion"
+	"go-siat/internal/core/domain/facturacion/operaciones"
+)
+
+type SiatOperacionesPort interface {
+	VerificarComunicacion(ctx context.Context, config facturacion.Config) (*soap.EnvelopeResponse[operaciones.VerificarComunicacionResponse], error)
+	RegistroPuntoVenta(ctx context.Context, config facturacion.Config, req *operaciones.RegistroPuntoVenta) (*soap.EnvelopeResponse[operaciones.RegistroPuntoVentaResponse], error)
+	ConsultaPuntoVenta(ctx context.Context, config facturacion.Config, req *operaciones.ConsultaPuntoVenta) (*soap.EnvelopeResponse[operaciones.ConsultaPuntoVentaResponse], error)
+	CierrePuntoVenta(ctx context.Context, config facturacion.Config, req *operaciones.CierrePuntoVenta) (*soap.EnvelopeResponse[operaciones.CierrePuntoVentaResponse], error)
+	RegistroPuntoVentaComisionista(ctx context.Context, config facturacion.Config, req *operaciones.RegistroPuntoVentaComisionista) (*soap.EnvelopeResponse[operaciones.RegistroPuntoVentaComisionistaResponse], error)
+	RegistroEventosSignificativos(ctx context.Context, config facturacion.Config, req *operaciones.RegistroEventoSignificativo) (*soap.EnvelopeResponse[operaciones.RegistroEventoSignificativoResponse], error)
+	ConsultaEventosSignificativos(ctx context.Context, config facturacion.Config, req *operaciones.ConsultaEventoSignificativo) (*soap.EnvelopeResponse[operaciones.ConsultaEventoSignificativoResponse], error)
+	CierreOperacionesSistema(ctx context.Context, config facturacion.Config, req *operaciones.CierreOperacionesSistema) (*soap.EnvelopeResponse[operaciones.CierreOperacionesSistemaResponse], error)
+}


### PR DESCRIPTION
- Implementa el puerto 'SiatOperacionesPort' y su servicio 'SiatOperacionesService' con soporte para:
    * Registro y consulta de Puntos de Venta.
    * Registro de eventos significativos.
    * Cierre de operaciones de sistema y puntos de venta.
    * Verificación de comunicación.
- Centraliza el formateo automático (indentación) de respuestas XML en 'index_service.go' para facilitar la depuración.
- Refactoriza los tests de integración actualizando parámetros críticos (CUIS, Punto de Venta, Motivos) y simplificando el registro de logs.
- Valida la estructura completa de las respuestas del SIAT en los logs de ejecución.