### PR TITLE
Fix builder names and response formats in computerized invoices

### DIFF
--- a/internal/adapter/service/index_service.go
+++ b/internal/adapter/service/index_service.go
@@ -21,6 +21,7 @@ const (
 	SiatSincronizacion SiatService = "FacturacionSincronizacion"
 	SiatCompraVenta    SiatService = "ServicioFacturacionCompraVenta"
 	SiatComputarizada  SiatService = "ServicioFacturacionComputarizada"
+	SiatElectronica    SiatService = "ServicioFacturacionElectronica"
 )
 
 // fullURL construye la URL completa para acceder a un servicio específico del SIAT,

--- a/internal/adapter/service/siat_compra_venta_service.go
+++ b/internal/adapter/service/siat_compra_venta_service.go
@@ -28,12 +28,12 @@ func (s *SiatCompraVentaService) RecepcionAnexos(ctx context.Context, config con
 }
 
 // ValidacionRecepcionMasivaFactura
-func (s *SiatCompraVentaService) ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFactura) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error) {
+func (s *SiatCompraVentaService) ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFacturaCompraVenta) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error) {
 	return performSoapRequest[facturacion.ValidacionRecepcionMasivaFactura, facturacion.ValidacionRecepcionMasivaFacturaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
 }
 
 // VerificacionEstadoFactura
-func (s *SiatCompraVentaService) VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFactura) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error) {
+func (s *SiatCompraVentaService) VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFacturaCompraVenta) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error) {
 	return performSoapRequest[facturacion.VerificacionEstadoFactura, facturacion.VerificacionEstadoFacturaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
 }
 

--- a/internal/adapter/service/siat_computarizada_service.go
+++ b/internal/adapter/service/siat_computarizada_service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ron86i/go-siat/internal/core/domain/datatype/soap"
-	"github.com/ron86i/go-siat/internal/core/domain/siat/computarizada"
 	"github.com/ron86i/go-siat/internal/core/domain/siat/facturacion"
 	"github.com/ron86i/go-siat/internal/core/port"
 	"github.com/ron86i/go-siat/pkg/config"
@@ -20,18 +19,19 @@ type siatComputarizadaService struct {
 	httpClient *http.Client
 }
 
-// RecepcionAnexosSuministroEnergia implements [port.SiatComputarizadaService].
-func (s *siatComputarizadaService) RecepcionAnexosSuministroEnergia(ctx context.Context, config config.Config, opaqueReq models.RecepcionAnexosSuministroEnergia) (*soap.EnvelopeResponse[computarizada.RecepcionAnexosSuministroEnergiaResponse], error) {
-	return performSoapRequest[computarizada.RecepcionAnexosSuministroEnergia, computarizada.RecepcionAnexosSuministroEnergiaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
+// RecepcionAnexosSuministroEnergia envía al SIAT la información detallada de los anexos
+// correspondientes a las recargas de suministro de energía eléctrica.
+func (s *siatComputarizadaService) RecepcionAnexosSuministroEnergia(ctx context.Context, config config.Config, opaqueReq models.RecepcionAnexosSuministroEnergiaComputarizada) (*soap.EnvelopeResponse[facturacion.RecepcionAnexosSuministroEnergiaResponse], error) {
+	return performSoapRequest[facturacion.RecepcionAnexosSuministroEnergia, facturacion.RecepcionAnexosSuministroEnergiaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
 }
 
-// RecepcionMasivaFactura implements [port.SiatComputarizadaService].
+// RecepcionMasivaFactura envía de forma masiva un paquete de facturas al SIAT.
 func (s *siatComputarizadaService) RecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.RecepcionMasivaFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.RecepcionMasivaFacturaResponse], error) {
 	return performSoapRequest[facturacion.RecepcionMasivaFactura, facturacion.RecepcionMasivaFacturaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
 }
 
 // ValidacionRecepcionMasivaFactura envia una solicitud al SIAT para validar la recepción de un paquete de facturas.
-func (s *siatComputarizadaService) ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFactura) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error) {
+func (s *siatComputarizadaService) ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error) {
 	return performSoapRequest[facturacion.ValidacionRecepcionMasivaFactura, facturacion.ValidacionRecepcionMasivaFacturaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
 }
 
@@ -41,7 +41,7 @@ func (s *siatComputarizadaService) ValidacionRecepcionPaqueteFactura(ctx context
 }
 
 // VerificacionEstadoFactura envia una solicitud al SIAT para verificar el estado de una factura.
-func (s *siatComputarizadaService) VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFactura) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error) {
+func (s *siatComputarizadaService) VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error) {
 	return performSoapRequest[facturacion.VerificacionEstadoFactura, facturacion.VerificacionEstadoFacturaResponse](ctx, s.httpClient, s.url, config.Token, opaqueReq)
 }
 

--- a/internal/adapter/service/siat_computarizada_service_test.go
+++ b/internal/adapter/service/siat_computarizada_service_test.go
@@ -1361,7 +1361,7 @@ func TestSiatComputarizadaService_VerificacionEstadoFactura(t *testing.T) {
 	cufd := cufdResp.Body.Content.RespuestaCufd.Codigo
 
 	// 3. Preparar solicitud de verificación
-	req := models.Computarizada().NewVerificacionEstadoFacturaComputarizadaBuilder().
+	req := models.Computarizada().NewVerificacionEstadoFacturaBuilder().
 		WithCodigoAmbiente(codAmbiente).
 		WithCodigoModalidad(codModalidad).
 		WithCodigoSistema(os.Getenv("SIAT_CODIGO_SISTEMA")).
@@ -1569,7 +1569,7 @@ func TestSiatComputarizadaService_ValidacionRecepcionPaqueteFactura(t *testing.T
 	cufd := cufdResp.Body.Content.RespuestaCufd.Codigo
 
 	// 2. Preparar solicitud
-	req := models.Computarizada().NewValidacionRecepcionPaqueteFacturaComputarizadaBuilder().
+	req := models.Computarizada().NewValidacionRecepcionPaqueteFacturaBuilder().
 		WithCodigoAmbiente(codAmbiente).
 		WithCodigoModalidad(codModalidad).
 		WithCodigoSistema(os.Getenv("SIAT_CODIGO_SISTEMA")).
@@ -1712,7 +1712,7 @@ func TestSiatComputarizadaService_RecepcionMasivaFactura(t *testing.T) {
 	encodedArchivo := base64.StdEncoding.EncodeToString(tarGz)
 
 	// 3. Preparar solicitud
-	req := models.Computarizada().NewRecepcionMasivaFacturaComputarizadaBuilder().
+	req := models.Computarizada().NewRecepcionMasivaFacturaBuilder().
 		WithCodigoAmbiente(codAmbiente).
 		WithCodigoModalidad(codModalidad).
 		WithCodigoSistema(os.Getenv("SIAT_CODIGO_SISTEMA")).
@@ -1782,7 +1782,7 @@ func TestSiatComputarizadaService_ValidacionRecepcionMasivaFactura(t *testing.T)
 	cufd := cufdResp.Body.Content.RespuestaCufd.Codigo
 
 	// 2. Preparar solicitud
-	req := models.Computarizada().NewValidacionRecepcionMasivaFacturaComputarizadaBuilder().
+	req := models.Computarizada().NewValidacionRecepcionMasivaFacturaBuilder().
 		WithCodigoAmbiente(codAmbiente).
 		WithCodigoModalidad(codModalidad).
 		WithCodigoSistema(os.Getenv("SIAT_CODIGO_SISTEMA")).

--- a/internal/core/domain/siat/facturacion/recepcion_anexos_suministro_energia.go
+++ b/internal/core/domain/siat/facturacion/recepcion_anexos_suministro_energia.go
@@ -1,10 +1,9 @@
-package computarizada
+package facturacion
 
 import (
 	"encoding/xml"
 
 	"github.com/ron86i/go-siat/internal/core/domain/datatype"
-	"github.com/ron86i/go-siat/internal/core/domain/siat/facturacion"
 )
 
 type RecepcionAnexosSuministroEnergia struct {
@@ -13,13 +12,13 @@ type RecepcionAnexosSuministroEnergia struct {
 }
 
 type SolicitudRecepcionAnexosSuministroEnergia struct {
-	facturacion.SolicitudRecepcion
+	SolicitudRecepcion
 	AnexosList []SuministroEnergiaAnexo `xml:"anexosList" json:"anexosList"`
 	GiftCard   int64                    `xml:"giftCard" json:"giftCard"`
 }
 
 type RecepcionAnexosSuministroEnergiaResponse struct {
-	RespuestaRecepcionAnexos facturacion.RespuestaRecepcion `xml:"RespuestaRecepcionAnexos" json:"respuestaRecepcionAnexos"`
+	RespuestaRecepcionAnexos RespuestaRecepcion `xml:"RespuestaRecepcionAnexos" json:"respuestaRecepcionAnexos"`
 }
 
 type SuministroEnergiaAnexo struct {

--- a/internal/core/port/siat_compra_venta_port.go
+++ b/internal/core/port/siat_compra_venta_port.go
@@ -40,10 +40,10 @@ type SiatCompraVentaService interface {
 	RecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.RecepcionMasivaFacturaCompraVenta) (*soap.EnvelopeResponse[facturacion.RecepcionMasivaFacturaResponse], error)
 
 	// ValidacionRecepcionMasivaFactura verifica el estado del procesamiento de un paquete enviado masivamente.
-	ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFactura) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error)
+	ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFacturaCompraVenta) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error)
 
 	// VerificacionEstadoFactura consulta el estado actual de una factura específica en los registros del SIAT.
-	VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFactura) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error)
+	VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFacturaCompraVenta) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error)
 
 	RecepcionAnexos(ctx context.Context, config config.Config, opaqueReq models.RecepcionAnexosCompraVenta) (*soap.EnvelopeResponse[compra_venta.RecepcionAnexosResponse], error)
 }

--- a/internal/core/port/siat_compurtarizada_port.go
+++ b/internal/core/port/siat_compurtarizada_port.go
@@ -4,15 +4,16 @@ import (
 	"context"
 
 	"github.com/ron86i/go-siat/internal/core/domain/datatype/soap"
-	"github.com/ron86i/go-siat/internal/core/domain/siat/computarizada"
 	"github.com/ron86i/go-siat/internal/core/domain/siat/facturacion"
 	"github.com/ron86i/go-siat/pkg/config"
 	"github.com/ron86i/go-siat/pkg/models"
 )
 
 type SiatComputarizadaService interface {
+	// AnulacionFactura envía una solicitud al SIAT para anular una factura previamente emitida y aceptada.
 	AnulacionFactura(ctx context.Context, config config.Config, opaqueReq models.AnulacionFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.AnulacionFacturaResponse], error)
 
+	// RecepcionFactura envía una factura computarizada al SIAT para su validación y recepción.
 	RecepcionFactura(ctx context.Context, config config.Config, opaqueReq models.RecepcionFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.RecepcionFacturaResponse], error)
 
 	// ReversionAnulacionFactura revierte la anulación de una factura previamente enviada al SIAT.
@@ -31,13 +32,18 @@ type SiatComputarizadaService interface {
 	// VerificarComunicacion realiza una prueba de conectividad con el servicio de operaciones del SIAT.
 	VerificarComunicacion(ctx context.Context, config config.Config, opaqueReq models.VerificarComunicacionComputarizada) (*soap.EnvelopeResponse[facturacion.VerificarComunicacionResponse], error)
 
+	// RecepcionMasivaFactura permite el envío de un paquete de facturas (mínimo 501, máximo 2000)
+	// para su procesamiento masivo por parte del SIAT.
 	RecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.RecepcionMasivaFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.RecepcionMasivaFacturaResponse], error)
 
 	// ValidacionRecepcionMasivaFactura verifica el estado del procesamiento de un paquete enviado masivamente.
-	ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFactura) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error)
+	ValidacionRecepcionMasivaFactura(ctx context.Context, config config.Config, opaqueReq models.ValidacionRecepcionMasivaFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.ValidacionRecepcionMasivaFacturaResponse], error)
 
 	// VerificacionEstadoFactura consulta el estado actual de una factura específica en los registros del SIAT.
-	VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFactura) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error)
+	VerificacionEstadoFactura(ctx context.Context, config config.Config, opaqueReq models.VerificacionEstadoFacturaComputarizada) (*soap.EnvelopeResponse[facturacion.VerificacionEstadoFacturaResponse], error)
 
-	RecepcionAnexosSuministroEnergia(ctx context.Context, config config.Config, opaqueReq models.RecepcionAnexosSuministroEnergia) (*soap.EnvelopeResponse[computarizada.RecepcionAnexosSuministroEnergiaResponse], error)
+	// RecepcionAnexosSuministroEnergia informa al SIAT sobre los anexos de recargas de suministro
+	// de energía eléctrica. Permite registrar el detalle de las recargas asociadas a facturas de
+	// suministro, incluyendo montos y fechas de recarga, así como el uso de gift cards.
+	RecepcionAnexosSuministroEnergia(ctx context.Context, config config.Config, opaqueReq models.RecepcionAnexosSuministroEnergiaComputarizada) (*soap.EnvelopeResponse[facturacion.RecepcionAnexosSuministroEnergiaResponse], error)
 }

--- a/pkg/models/compra_venta.go
+++ b/pkg/models/compra_venta.go
@@ -19,13 +19,13 @@ type RecepcionAnexosCompraVenta struct {
 	requestWrapper[compra_venta.RecepcionAnexos]
 }
 
-// VerificacionEstadoFactura representa una solicitud para la verificación del estado de una factura.
-type VerificacionEstadoFactura struct {
+// VerificacionEstadoFacturaCompraVenta representa una solicitud para la verificación del estado de una factura.
+type VerificacionEstadoFacturaCompraVenta struct {
 	requestWrapper[facturacion.VerificacionEstadoFactura]
 }
 
-// ValidacionRecepcionMasivaFactura representa una solicitud para la validación de la recepción masiva de facturas.
-type ValidacionRecepcionMasivaFactura struct {
+// ValidacionRecepcionMasivaFacturaCompraVenta representa una solicitud para la validación de la recepción masiva de facturas.
+type ValidacionRecepcionMasivaFacturaCompraVenta struct {
 	requestWrapper[facturacion.ValidacionRecepcionMasivaFactura]
 }
 
@@ -771,8 +771,8 @@ func (b *verificacionEstadoFacturaBuilder) WithCuf(cuf string) *verificacionEsta
 	return b
 }
 
-func (b *verificacionEstadoFacturaBuilder) Build() VerificacionEstadoFactura {
-	return VerificacionEstadoFactura{requestWrapper[facturacion.VerificacionEstadoFactura]{request: b.request}}
+func (b *verificacionEstadoFacturaBuilder) Build() VerificacionEstadoFacturaCompraVenta {
+	return VerificacionEstadoFacturaCompraVenta{requestWrapper[facturacion.VerificacionEstadoFactura]{request: b.request}}
 }
 
 type validacionRecepcionMasivaFacturaBuilder struct {
@@ -839,6 +839,6 @@ func (b *validacionRecepcionMasivaFacturaBuilder) WithCodigoRecepcion(codigoRece
 	return b
 }
 
-func (b *validacionRecepcionMasivaFacturaBuilder) Build() ValidacionRecepcionMasivaFactura {
-	return ValidacionRecepcionMasivaFactura{requestWrapper[facturacion.ValidacionRecepcionMasivaFactura]{request: b.request}}
+func (b *validacionRecepcionMasivaFacturaBuilder) Build() ValidacionRecepcionMasivaFacturaCompraVenta {
+	return ValidacionRecepcionMasivaFacturaCompraVenta{requestWrapper[facturacion.ValidacionRecepcionMasivaFactura]{request: b.request}}
 }

--- a/pkg/models/computarizada.go
+++ b/pkg/models/computarizada.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/ron86i/go-siat/internal/core/domain/datatype"
-	"github.com/ron86i/go-siat/internal/core/domain/siat/computarizada"
 	"github.com/ron86i/go-siat/internal/core/domain/siat/facturacion"
 )
 
@@ -42,12 +41,20 @@ type RecepcionMasivaFacturaComputarizada struct {
 	requestWrapper[facturacion.RecepcionMasivaFactura]
 }
 
-type RecepcionAnexosSuministroEnergia struct {
-	requestWrapper[computarizada.RecepcionAnexosSuministroEnergia]
+type RecepcionAnexosSuministroEnergiaComputarizada struct {
+	requestWrapper[facturacion.RecepcionAnexosSuministroEnergia]
 }
 
 type SuministroEnergiaAnexoComputarizada struct {
-	requestWrapper[computarizada.SuministroEnergiaAnexo]
+	requestWrapper[facturacion.SuministroEnergiaAnexo]
+}
+
+type ValidacionRecepcionMasivaFacturaComputarizada struct {
+	requestWrapper[facturacion.ValidacionRecepcionMasivaFactura]
+}
+
+type VerificacionEstadoFacturaComputarizada struct {
+	requestWrapper[facturacion.VerificacionEstadoFactura]
 }
 
 // --- Namespace ---
@@ -94,104 +101,108 @@ func (computarizadaNamespace) NewRecepcionPaqueteFacturaBuilder() *recepcionPaqu
 	}
 }
 
-func (computarizadaNamespace) NewValidacionRecepcionPaqueteFacturaComputarizadaBuilder() *validacionRecepcionPaqueteFacturaComputarizadaBuilder {
+// NewValidacionRecepcionPaqueteFacturaBuilder crea un constructor para la solicitud de validación de paquete de factura.
+func (computarizadaNamespace) NewValidacionRecepcionPaqueteFacturaBuilder() *validacionRecepcionPaqueteFacturaComputarizadaBuilder {
 	return &validacionRecepcionPaqueteFacturaComputarizadaBuilder{
 		request: &facturacion.ValidacionRecepcionPaqueteFactura{},
 	}
 }
 
-func (computarizadaNamespace) NewValidacionRecepcionMasivaFacturaComputarizadaBuilder() *validacionRecepcionMasivaFacturaComputarizadaBuilder {
+// NewValidacionRecepcionMasivaFacturaBuilder crea un constructor para la solicitud de validación de recepción masiva de factura.
+func (computarizadaNamespace) NewValidacionRecepcionMasivaFacturaBuilder() *validacionRecepcionMasivaFacturaComputarizadaBuilder {
 	return &validacionRecepcionMasivaFacturaComputarizadaBuilder{
 		request: &facturacion.ValidacionRecepcionMasivaFactura{},
 	}
 }
 
-func (computarizadaNamespace) NewVerificacionEstadoFacturaComputarizadaBuilder() *verificacionEstadoFacturaComputarizadaBuilder {
+// NewVerificacionEstadoFacturaBuilder crea un constructor para la solicitud de verificación de estado de factura.
+func (computarizadaNamespace) NewVerificacionEstadoFacturaBuilder() *verificacionEstadoFacturaComputarizadaBuilder {
 	return &verificacionEstadoFacturaComputarizadaBuilder{
 		request: &facturacion.VerificacionEstadoFactura{},
 	}
 }
 
-func (computarizadaNamespace) NewRecepcionMasivaFacturaComputarizadaBuilder() *recepcionMasivaFacturaComputarizadaBuilder {
+// NewRecepcionMasivaFacturaBuilder crea un constructor para la solicitud de recepción masiva de factura.
+func (computarizadaNamespace) NewRecepcionMasivaFacturaBuilder() *recepcionMasivaFacturaComputarizadaBuilder {
 	return &recepcionMasivaFacturaComputarizadaBuilder{
 		request: &facturacion.RecepcionMasivaFactura{},
 	}
 }
 
-func (computarizadaNamespace) NewRecepcionAnexosSuministroEnergiaBuilder() *recepcionAnexosSuministroEnergiaBuilder {
-	return &recepcionAnexosSuministroEnergiaBuilder{
-		request: &computarizada.RecepcionAnexosSuministroEnergia{},
+func (computarizadaNamespace) NewRecepcionAnexosSuministroEnergiaBuilder() *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
+	return &recepcionAnexosSuministroEnergiaComputarizadaBuilder{
+		request: &facturacion.RecepcionAnexosSuministroEnergia{},
 	}
 }
 
-func (computarizadaNamespace) NewSuministroEnergiaAnexoBuilder() *suministroEnergiaAnexoBuilder {
-	return &suministroEnergiaAnexoBuilder{
-		request: &computarizada.SuministroEnergiaAnexo{},
+func (computarizadaNamespace) NewSuministroEnergiaAnexoBuilder() *suministroEnergiaAnexoComputarizadaBuilder {
+	return &suministroEnergiaAnexoComputarizadaBuilder{
+		request: &facturacion.SuministroEnergiaAnexo{},
 	}
 }
 
 // --- Implementaciones de Builders ---
 
-type recepcionAnexosSuministroEnergiaBuilder struct {
-	request *computarizada.RecepcionAnexosSuministroEnergia
+type recepcionAnexosSuministroEnergiaComputarizadaBuilder struct {
+	request *facturacion.RecepcionAnexosSuministroEnergia
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoAmbiente(codigoAmbiente int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoAmbiente(codigoAmbiente int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoAmbiente = codigoAmbiente
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoDocumentoSector(codigoDocumentoSector int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoDocumentoSector(codigoDocumentoSector int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoDocumentoSector = codigoDocumentoSector
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoEmision(codigoEmision int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoEmision(codigoEmision int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoEmision = codigoEmision
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoModalidad(codigoModalidad int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoModalidad(codigoModalidad int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoModalidad = codigoModalidad
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoPuntoVenta(codigoPuntoVenta int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoPuntoVenta(codigoPuntoVenta int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoPuntoVenta = codigoPuntoVenta
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoSistema(codigoSistema string) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoSistema(codigoSistema string) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoSistema = codigoSistema
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCodigoSucursal(codigoSucursal int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCodigoSucursal(codigoSucursal int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.CodigoSucursal = codigoSucursal
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCufd(cufd string) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCufd(cufd string) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.Cufd = cufd
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithCuis(cuis string) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithCuis(cuis string) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.Cuis = cuis
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithNit(nit int64) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithNit(nit int64) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.Nit = nit
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithTipoFacturaDocumento(tipo int) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithTipoFacturaDocumento(tipo int) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.TipoFacturaDocumento = tipo
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) AddAnexos(anexos ...SuministroEnergiaAnexoComputarizada) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) AddAnexos(anexos ...SuministroEnergiaAnexoComputarizada) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	for _, anexo := range anexos {
 		if anexo.request != nil {
 			b.request.SolicitudRecepcionSuministroAnexos.AnexosList = append(b.request.SolicitudRecepcionSuministroAnexos.AnexosList, *anexo.request)
@@ -200,36 +211,36 @@ func (b *recepcionAnexosSuministroEnergiaBuilder) AddAnexos(anexos ...Suministro
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) WithGiftCard(giftCard int64) *recepcionAnexosSuministroEnergiaBuilder {
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) WithGiftCard(giftCard int64) *recepcionAnexosSuministroEnergiaComputarizadaBuilder {
 	b.request.SolicitudRecepcionSuministroAnexos.GiftCard = giftCard
 	return b
 }
 
-func (b *recepcionAnexosSuministroEnergiaBuilder) Build() RecepcionAnexosSuministroEnergia {
-	return RecepcionAnexosSuministroEnergia{requestWrapper[computarizada.RecepcionAnexosSuministroEnergia]{request: b.request}}
+func (b *recepcionAnexosSuministroEnergiaComputarizadaBuilder) Build() RecepcionAnexosSuministroEnergiaComputarizada {
+	return RecepcionAnexosSuministroEnergiaComputarizada{requestWrapper[facturacion.RecepcionAnexosSuministroEnergia]{request: b.request}}
 }
 
-type suministroEnergiaAnexoBuilder struct {
-	request *computarizada.SuministroEnergiaAnexo
+type suministroEnergiaAnexoComputarizadaBuilder struct {
+	request *facturacion.SuministroEnergiaAnexo
 }
 
-func (b *suministroEnergiaAnexoBuilder) WithCufFactSuministro(cuf string) *suministroEnergiaAnexoBuilder {
+func (b *suministroEnergiaAnexoComputarizadaBuilder) WithCufFactSuministro(cuf string) *suministroEnergiaAnexoComputarizadaBuilder {
 	b.request.CufFactSuministro = cuf
 	return b
 }
 
-func (b *suministroEnergiaAnexoBuilder) WithFechaRecarga(fecha time.Time) *suministroEnergiaAnexoBuilder {
+func (b *suministroEnergiaAnexoComputarizadaBuilder) WithFechaRecarga(fecha time.Time) *suministroEnergiaAnexoComputarizadaBuilder {
 	b.request.FechaRecarga = datatype.NewTimeSiat(fecha)
 	return b
 }
 
-func (b *suministroEnergiaAnexoBuilder) WithMontoRecarga(monto float64) *suministroEnergiaAnexoBuilder {
+func (b *suministroEnergiaAnexoComputarizadaBuilder) WithMontoRecarga(monto float64) *suministroEnergiaAnexoComputarizadaBuilder {
 	b.request.MontoRecarga = monto
 	return b
 }
 
-func (b *suministroEnergiaAnexoBuilder) Build() SuministroEnergiaAnexoComputarizada {
-	return SuministroEnergiaAnexoComputarizada{requestWrapper[computarizada.SuministroEnergiaAnexo]{request: b.request}}
+func (b *suministroEnergiaAnexoComputarizadaBuilder) Build() SuministroEnergiaAnexoComputarizada {
+	return SuministroEnergiaAnexoComputarizada{requestWrapper[facturacion.SuministroEnergiaAnexo]{request: b.request}}
 }
 
 type recepcionMasivaFacturaComputarizadaBuilder struct {
@@ -365,8 +376,8 @@ func (b *verificacionEstadoFacturaComputarizadaBuilder) WithCuf(cuf string) *ver
 	return b
 }
 
-func (b *verificacionEstadoFacturaComputarizadaBuilder) Build() VerificacionEstadoFactura {
-	return VerificacionEstadoFactura{requestWrapper[facturacion.VerificacionEstadoFactura]{request: b.request}}
+func (b *verificacionEstadoFacturaComputarizadaBuilder) Build() VerificacionEstadoFacturaComputarizada {
+	return VerificacionEstadoFacturaComputarizada{requestWrapper[facturacion.VerificacionEstadoFactura]{request: b.request}}
 }
 
 type validacionRecepcionMasivaFacturaComputarizadaBuilder struct {
@@ -433,8 +444,8 @@ func (b *validacionRecepcionMasivaFacturaComputarizadaBuilder) WithCodigoRecepci
 	return b
 }
 
-func (b *validacionRecepcionMasivaFacturaComputarizadaBuilder) Build() ValidacionRecepcionMasivaFactura {
-	return ValidacionRecepcionMasivaFactura{requestWrapper[facturacion.ValidacionRecepcionMasivaFactura]{request: b.request}}
+func (b *validacionRecepcionMasivaFacturaComputarizadaBuilder) Build() ValidacionRecepcionMasivaFacturaComputarizada {
+	return ValidacionRecepcionMasivaFacturaComputarizada{requestWrapper[facturacion.ValidacionRecepcionMasivaFactura]{request: b.request}}
 }
 
 type recepcionPaqueteFacturaComputarizadaBuilder struct {


### PR DESCRIPTION
- Fixed an issue where computerized invoice builders were using inconsistent names and returning the wrong response formats. Updates were also made to the service tests to ensure everything works correctly with these fixes.
- Fix whitespace in function documentation