### PR TITLE
feat: metadatos fiscales y recepción tipada SIAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Coverage files (added by CoverLens)
 coverage.out
+.siat-traces/
 
 # AI Agents & RAG Documentation
 AGENT.md

--- a/constants.go
+++ b/constants.go
@@ -1,5 +1,7 @@
 package siat
 
+import "github.com/ron86i/go-siat/v2/pkg/models"
+
 const (
 	// AmbienteProduccion (1): Operaciones reales con validez tributaria.
 	AmbienteProduccion = iota + 1
@@ -21,4 +23,14 @@ const (
 	EmisionOffline
 	// EmisionMasiva (3): Para procesos de alta demanda de facturación.
 	EmisionMasiva
+)
+
+// Tipos de documento fiscal definidos por el SIAT.
+const (
+	// Estos alias mantienen la API del paquete raíz; la definición canónica
+	// está en pkg/models, que es donde la consumen los builders de facturas.
+	TipoFacturaConDerechoCreditoFiscal = models.TipoFacturaConDerechoCreditoFiscal
+	TipoFacturaSinDerechoCreditoFiscal = models.TipoFacturaSinDerechoCreditoFiscal
+	TipoNotaCreditoDebito              = models.TipoNotaCreditoDebito
+	TipoBoletoAereo                    = models.TipoBoletoAereo
 )

--- a/internal/adapter/services/siat_codigos_service_test.go
+++ b/internal/adapter/services/siat_codigos_service_test.go
@@ -139,7 +139,7 @@ func TestSolicitudCuis(t *testing.T) {
 
 	req := models.NewCuisBuilder().
 		WithCodigoSucursal(0).
-		WithCodigoPuntoVenta(1).
+		WithCodigoPuntoVenta(12).
 		WithCodigoModalidad(codModalidad).
 		Build()
 

--- a/internal/adapter/services/siat_operaciones_service_test.go
+++ b/internal/adapter/services/siat_operaciones_service_test.go
@@ -1,16 +1,81 @@
 package services_test
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/ron86i/go-siat/v2"
 	"github.com/ron86i/go-siat/v2/pkg/models"
+	"github.com/ron86i/go-siat/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+type xmlTraceTransport struct {
+	t         *testing.T
+	base      http.RoundTripper
+	outputDir string
+	sequence  int
+}
+
+func (t *xmlTraceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	t.sequence++
+	sequence := t.sequence
+	t.writeXML(sequence, "solicitud", body)
+	t.t.Logf("XML enviado al SIAT:\n%s", body)
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(responseBody))
+	t.writeXML(sequence, "respuesta", responseBody)
+	t.t.Logf("XML recibido del SIAT:\n%s", responseBody)
+
+	return resp, nil
+}
+
+func (t *xmlTraceTransport) writeXML(sequence int, kind string, body []byte) {
+	filename := fmt.Sprintf("%02d-%s.xml", sequence, kind)
+	path := filepath.Join(t.outputDir, filename)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.t.Logf("no se pudo guardar XML de %s: %v", kind, err)
+		return
+	}
+	t.t.Logf("XML de %s guardado en %s", kind, path)
+}
+
+func newXMLTraceHTTPClient(t *testing.T) *http.Client {
+	t.Helper()
+	outputDir := ".siat-traces"
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
+		t.Fatalf("no se pudo crear directorio de trazas XML: %v", err)
+	}
+	return &http.Client{
+		Transport: &xmlTraceTransport{
+			t:         t,
+			base:      http.DefaultTransport,
+			outputDir: outputDir,
+		},
+	}
+}
 
 func TestConsultaPuntoVenta(t *testing.T) {
 	if _, err := os.Stat(".env"); os.IsNotExist(err) {
@@ -18,9 +83,10 @@ func TestConsultaPuntoVenta(t *testing.T) {
 	}
 	godotenv.Load(".env")
 
+	nit, err := utils.ParseInt64Safe(os.Getenv("SIAT_NIT"))
 	cfg := siat.Config{
 		Token:          os.Getenv("SIAT_TOKEN"),
-		Nit:            123456789,
+		Nit:            nit,
 		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
 		CodigoAmbiente: siat.AmbientePruebas,
 		BaseURL:        os.Getenv("SIAT_URL"),
@@ -42,5 +108,357 @@ func TestConsultaPuntoVenta(t *testing.T) {
 	resp, err := service.ConsultaPuntoVenta(context.Background(), req)
 	if err == nil && assert.NotNil(t, resp) {
 		assert.NotNil(t, resp.Body.Content)
+	}
+}
+
+func TestSolicitudCuisYConsultaPuntosVenta(t *testing.T) {
+	if _, err := os.Stat(".env"); os.IsNotExist(err) {
+		t.Skip("Saltando prueba de integración: .env no encontrado")
+	}
+
+	if err := godotenv.Load(".env"); err != nil {
+		t.Fatalf("error cargando .env: %v", err)
+	}
+
+	nit, err := utils.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	if err != nil {
+		t.Fatalf("SIAT_NIT inválido: %v", err)
+	}
+
+	codModalidad, err := utils.ParseIntSafe(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+	if err != nil {
+		t.Fatalf("SIAT_CODIGO_MODALIDAD inválido: %v", err)
+	}
+
+	cfg := siat.Config{
+		Token:          os.Getenv("SIAT_TOKEN"),
+		Nit:            nit,
+		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
+		CodigoAmbiente: siat.AmbientePruebas,
+		BaseURL:        os.Getenv("SIAT_URL"),
+		HTTPClient:     &http.Client{},
+	}
+
+	siatClient, err := siat.New(cfg)
+	if err != nil {
+		t.Fatalf("error creando cliente: %v", err)
+	}
+
+	ctx := context.Background()
+	codigoSucursal := 0
+	codigoPuntoVenta := 0
+
+	// 1. Obtener CUIS
+	cuisReq := models.NewCuisBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoPuntoVenta(codigoPuntoVenta).
+		WithCodigoModalidad(codModalidad).
+		Build()
+
+	cuisResp, err := siatClient.Codigos().SolicitudCuis(ctx, cuisReq)
+	if err != nil {
+		t.Fatalf("error solicitando CUIS: %v", err)
+	}
+
+	resultadoCuis := cuisResp.Body.Content.RespuestaCuis
+	if resultadoCuis.Codigo == "" {
+		t.Fatalf("SIAT no devolvió CUIS: %+v", resultadoCuis.MensajesList)
+	}
+
+	t.Logf("CUIS obtenido: %s", resultadoCuis.Codigo)
+
+	// 2. Consultar puntos de venta usando el CUIS
+	puntosReq := models.NewConsultaPuntoVentaBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCuis(resultadoCuis.Codigo).
+		Build()
+
+	puntosResp, err := siatClient.Operaciones().ConsultaPuntoVenta(ctx, puntosReq)
+	if err != nil {
+		t.Fatalf("error consultando puntos de venta: %v", err)
+	}
+
+	resultadoPuntos := puntosResp.Body.Content.Respuesta
+	if !resultadoPuntos.Transaccion {
+		t.Fatalf("consulta rechazada: %+v", resultadoPuntos.MensajesList)
+	}
+
+	for _, punto := range resultadoPuntos.ListaPuntosVentas {
+		t.Logf(
+			"Punto de venta: código=%d, nombre=%s, tipo=%s",
+			punto.CodigoPuntoVenta,
+			punto.NombrePuntoVenta,
+			punto.TipoPuntoVenta,
+		)
+	}
+}
+
+func TestSolicitudCuisYCierreOperaciones(t *testing.T) {
+	if _, err := os.Stat(".env"); os.IsNotExist(err) {
+		t.Skip("Saltando prueba de integración: .env no encontrado")
+	}
+
+	if err := godotenv.Load(".env"); err != nil {
+		t.Fatalf("error cargando .env: %v", err)
+	}
+
+	nit, err := utils.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	if err != nil {
+		t.Fatalf("SIAT_NIT inválido: %v", err)
+	}
+
+	codModalidad, err := utils.ParseIntSafe(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+	if err != nil {
+		t.Fatalf("SIAT_CODIGO_MODALIDAD inválido: %v", err)
+	}
+
+	siatClient, err := siat.New(siat.Config{
+		Token:          os.Getenv("SIAT_TOKEN"),
+		Nit:            nit,
+		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
+		CodigoAmbiente: siat.AmbientePruebas,
+		BaseURL:        os.Getenv("SIAT_URL"),
+		HTTPClient:     &http.Client{},
+	})
+	if err != nil {
+		t.Fatalf("error creando cliente: %v", err)
+	}
+
+	ctx := context.Background()
+	codigoSucursal := 0
+	codigoPuntoVenta := 0
+
+	// 1. Obtener un CUIS para la sucursal y punto de venta.
+	cuisReq := models.NewCuisBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoPuntoVenta(codigoPuntoVenta).
+		WithCodigoModalidad(codModalidad).
+		Build()
+
+	cuisResp, err := siatClient.Codigos().SolicitudCuis(ctx, cuisReq)
+	if err != nil {
+		t.Fatalf("error solicitando CUIS: %v", err)
+	}
+
+	resultadoCuis := cuisResp.Body.Content.RespuestaCuis
+	if resultadoCuis.Codigo == "" {
+		t.Fatalf("SIAT no devolvió CUIS: %+v", resultadoCuis.MensajesList)
+	}
+	t.Logf("CUIS obtenido: %s (transacción: %v, vigencia: %s)",
+		resultadoCuis.Codigo,
+		resultadoCuis.Transaccion,
+		resultadoCuis.FechaVigencia.Format(time.RFC3339),
+	)
+
+	// 2. Cerrar las operaciones del sistema usando el CUIS obtenido.
+	cierreReq := models.NewCierreOperacionesSistemaBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoPuntoVenta(codigoPuntoVenta).
+		WithCodigoModalidad(codModalidad).
+		WithCuis(resultadoCuis.Codigo).
+		Build()
+
+	cierreResp, err := siatClient.Operaciones().CierreOperacionesSistema(ctx, cierreReq)
+	if err != nil {
+		t.Fatalf("error cerrando operaciones: %v", err)
+	}
+
+	resultadoCierre := cierreResp.Body.Content.Respuesta
+	for _, mensaje := range resultadoCierre.MensajesList {
+		t.Logf("Mensaje SIAT [%d]: %s", mensaje.Codigo, mensaje.Descripcion)
+	}
+
+	assert.True(t, resultadoCierre.Transaccion,
+		"el cierre de operaciones fue rechazado: %+v", resultadoCierre.MensajesList)
+}
+
+func TestSolicitudCuisYRegistroPuntoVenta(t *testing.T) {
+	if _, err := os.Stat(".env"); os.IsNotExist(err) {
+		t.Skip("Saltando prueba de integración: .env no encontrado")
+	}
+
+	if err := godotenv.Load(".env"); err != nil {
+		t.Fatalf("error cargando .env: %v", err)
+	}
+
+	nit, err := utils.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	if err != nil {
+		t.Fatalf("SIAT_NIT inválido: %v", err)
+	}
+
+	codModalidad, err := utils.ParseIntSafe(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+	if err != nil {
+		t.Fatalf("SIAT_CODIGO_MODALIDAD inválido: %v", err)
+	}
+
+	codTipoPuntoVenta := 5
+
+	siatClient, err := siat.New(siat.Config{
+		Token:          os.Getenv("SIAT_TOKEN"),
+		Nit:            nit,
+		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
+		CodigoAmbiente: siat.AmbientePruebas,
+		BaseURL:        os.Getenv("SIAT_URL"),
+		HTTPClient:     &http.Client{},
+	})
+	if err != nil {
+		t.Fatalf("error creando cliente: %v", err)
+	}
+
+	ctx := context.Background()
+	codigoSucursal := 0
+	// El CUIS de registro debe corresponder al sistema de la sucursal,
+	// normalmente el punto de venta principal (0).
+	codigoPuntoVentaPrincipal := 0
+
+	cuisReq := models.NewCuisBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoPuntoVenta(codigoPuntoVentaPrincipal).
+		WithCodigoModalidad(codModalidad).
+		Build()
+
+	cuisResp, err := siatClient.Codigos().SolicitudCuis(ctx, cuisReq)
+	if err != nil {
+		t.Fatalf("error solicitando CUIS: %v", err)
+	}
+
+	resultadoCuis := cuisResp.Body.Content.RespuestaCuis
+	if resultadoCuis.Codigo == "" {
+		t.Fatalf("SIAT no devolvió CUIS: %+v", resultadoCuis.MensajesList)
+	}
+	t.Logf("CUIS obtenido: %s", resultadoCuis.Codigo)
+
+	nombre := "PV-PRUEBA-" + time.Now().Format("20060102-150405")
+	registroReq := models.NewRegistroPuntoVentaBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoModalidad(codModalidad).
+		WithCodigoTipoPuntoVenta(codTipoPuntoVenta).
+		WithCuis(resultadoCuis.Codigo).
+		WithNombrePuntoVenta(nombre).
+		WithDescripcion("Punto de venta creado por prueba de integración").
+		Build()
+
+	registroResp, err := siatClient.Operaciones().RegistroPuntoVenta(ctx, registroReq)
+	if err != nil {
+		t.Fatalf("error registrando punto de venta: %v", err)
+	}
+
+	resultadoRegistro := registroResp.Body.Content.Respuesta
+	for _, mensaje := range resultadoRegistro.MensajesList {
+		t.Logf("Mensaje SIAT [%d]: %s", mensaje.Codigo, mensaje.Descripcion)
+	}
+
+	assert.True(t, resultadoRegistro.Transaccion,
+		"registro rechazado: %+v", resultadoRegistro.MensajesList)
+	if resultadoRegistro.Transaccion {
+		t.Logf("Punto de venta registrado: código=%d, nombre=%s",
+			resultadoRegistro.CodigoPuntoVenta, nombre)
+	}
+}
+
+func TestSolicitudCuisYCierrePuntoVenta(t *testing.T) {
+	if _, err := os.Stat(".env"); os.IsNotExist(err) {
+		t.Skip("Saltando prueba de integración: .env no encontrado")
+	}
+
+	if err := godotenv.Load(".env"); err != nil {
+		t.Fatalf("error cargando .env: %v", err)
+	}
+
+	nit, err := utils.ParseInt64Safe(os.Getenv("SIAT_NIT"))
+	if err != nil {
+		t.Fatalf("SIAT_NIT inválido: %v", err)
+	}
+
+	codModalidad, err := utils.ParseIntSafe(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+	if err != nil {
+		t.Fatalf("SIAT_CODIGO_MODALIDAD inválido: %v", err)
+	}
+
+	codigoPuntoVenta := 11
+	siatClient, err := siat.New(siat.Config{
+		Token:          os.Getenv("SIAT_TOKEN"),
+		Nit:            nit,
+		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
+		CodigoAmbiente: siat.AmbientePruebas,
+		BaseURL:        os.Getenv("SIAT_URL"),
+		HTTPClient:     newXMLTraceHTTPClient(t),
+	})
+	if err != nil {
+		t.Fatalf("error creando cliente: %v", err)
+	}
+
+	ctx := context.Background()
+	codigoSucursal := 0
+
+	// El CUIS identifica el sistema en la sucursal; el punto de venta a
+	// cerrar se indica por separado en la solicitud de cierre.
+	cuisReq := models.NewCuisBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoPuntoVenta(0).
+		WithCodigoModalidad(codModalidad).
+		Build()
+
+	cuisResp, err := siatClient.Codigos().SolicitudCuis(ctx, cuisReq)
+	if err != nil {
+		t.Fatalf("error solicitando CUIS: %v", err)
+	}
+
+	resultadoCuis := cuisResp.Body.Content.RespuestaCuis
+	if resultadoCuis.Codigo == "" {
+		t.Fatalf("SIAT no devolvió CUIS: %+v", resultadoCuis.MensajesList)
+	}
+	t.Logf("CUIS obtenido para sucursal %d: %s (transacción: %v)",
+		codigoSucursal, resultadoCuis.Codigo, resultadoCuis.Transaccion)
+
+	// Confirmar que el punto existe antes de ejecutar una operación destructiva.
+	consultaReq := models.NewConsultaPuntoVentaBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCuis(resultadoCuis.Codigo).
+		Build()
+
+	consultaResp, err := siatClient.Operaciones().ConsultaPuntoVenta(ctx, consultaReq)
+	if err != nil {
+		t.Fatalf("error consultando puntos de venta: %v", err)
+	}
+
+	resultadoConsulta := consultaResp.Body.Content.Respuesta
+	if !resultadoConsulta.Transaccion {
+		t.Fatalf("consulta de puntos de venta rechazada: %+v", resultadoConsulta.MensajesList)
+	}
+
+	existePuntoVenta := false
+	codigosDisponibles := make([]int, 0, len(resultadoConsulta.ListaPuntosVentas))
+	for _, punto := range resultadoConsulta.ListaPuntosVentas {
+		codigosDisponibles = append(codigosDisponibles, punto.CodigoPuntoVenta)
+		if punto.CodigoPuntoVenta == codigoPuntoVenta {
+			existePuntoVenta = true
+		}
+	}
+	if !existePuntoVenta {
+		t.Fatalf("el punto de venta %d no existe en la sucursal %d; códigos disponibles: %v",
+			codigoPuntoVenta, codigoSucursal, codigosDisponibles)
+	}
+
+	cierreReq := models.NewCierrePuntoVentaBuilder().
+		WithCodigoSucursal(codigoSucursal).
+		WithCodigoPuntoVenta(codigoPuntoVenta).
+		WithCuis(resultadoCuis.Codigo).
+		Build()
+
+	cierreResp, err := siatClient.Operaciones().CierrePuntoVenta(ctx, cierreReq)
+	if err != nil {
+		t.Fatalf("error cerrando punto de venta: %v", err)
+	}
+
+	resultadoCierre := cierreResp.Body.Content.Respuesta
+	for _, mensaje := range resultadoCierre.MensajesList {
+		t.Logf("Mensaje SIAT [%d]: %s", mensaje.Codigo, mensaje.Descripcion)
+	}
+
+	assert.True(t, resultadoCierre.Transaccion,
+		"cierre de punto de venta rechazado: %+v", resultadoCierre.MensajesList)
+	if resultadoCierre.Transaccion {
+		t.Logf("Punto de venta cerrado: código=%d", resultadoCierre.CodigoPuntoVenta)
 	}
 }

--- a/internal/core/domain/siat/operaciones/operaciones.go
+++ b/internal/core/domain/siat/operaciones/operaciones.go
@@ -12,7 +12,7 @@ type CierreOperacionesSistema struct {
 type SolicitudOperaciones struct {
 	CodigoAmbiente   int    `xml:"codigoAmbiente" json:"codigoAmbiente"`
 	CodigoModalidad  int    `xml:"codigoModalidad" json:"codigoModalidad"`
-	CodigoPuntoVenta int    `xml:"codigoPuntoVenta,omitempty" json:"codigoPuntoVenta,omitempty"`
+	CodigoPuntoVenta int    `xml:"codigoPuntoVenta" json:"codigoPuntoVenta"`
 	CodigoSistema    string `xml:"codigoSistema" json:"codigoSistema"`
 	CodigoSucursal   int    `xml:"codigoSucursal" json:"codigoSucursal"`
 	Cuis             string `xml:"cuis" json:"cuis"`

--- a/pkg/models/documento_ajuste.go
+++ b/pkg/models/documento_ajuste.go
@@ -66,7 +66,8 @@ func NewVerificarComunicacionDocumentoAjusteBuilder() *verificarComunicacionDocu
 // -- Implementaciones de Builders --
 
 type recepcionDocumentoAjusteBuilder struct {
-	request *documento_ajuste.RecepcionDocumentoAjuste
+	request                   *documento_ajuste.RecepcionDocumentoAjuste
+	firmaElectronicaRequerida bool
 }
 
 func (b *recepcionDocumentoAjusteBuilder) WithCodigoModalidad(v int) *recepcionDocumentoAjusteBuilder {
@@ -124,15 +125,46 @@ func (b *recepcionDocumentoAjusteBuilder) WithHashArchivo(v string) *recepcionDo
 	return b
 }
 
+// WithFirmaElectronicaRequerida exige un XMLSigner cuando la modalidad sea
+// electrónica. No afecta la modalidad computarizada ni el comportamiento
+// existente mientras no se invoque explícitamente.
+func (b *recepcionDocumentoAjusteBuilder) WithFirmaElectronicaRequerida() *recepcionDocumentoAjusteBuilder {
+	b.firmaElectronicaRequerida = true
+	return b
+}
+
+// WithDocumentoFiscal es la alternativa tipada a WithDocumento. Garantiza en
+// compilación que el documento expone sector y tipo fiscal.
+func (b *recepcionDocumentoAjusteBuilder) WithDocumentoFiscal(documento FacturaConMetadatos, signer XMLSigner) error {
+	return b.WithDocumento(documento, signer)
+}
+
 // WithDocumento serializa, firma (si se provee signer), comprime y calcula el hash del documento de ajuste automáticamente,
 // mapeando los valores obtenidos en los campos Archivo y HashArchivo de la solicitud.
 func (b *recepcionDocumentoAjusteBuilder) WithDocumento(documento any, signer XMLSigner) error {
+	solicitud := &b.request.SolicitudRecepcionFactura
+	if fiscal, ok := documento.(FacturaConMetadatos); ok {
+		if solicitud.CodigoDocumentoSector == 0 {
+			solicitud.CodigoDocumentoSector = fiscal.CodigoDocumentoSector()
+		}
+		if solicitud.TipoFacturaDocumento == 0 {
+			solicitud.TipoFacturaDocumento = fiscal.TipoFacturaDocumento()
+		}
+	} else if solicitud.TipoFacturaDocumento == 0 {
+		if fiscal, ok := documento.(FacturaConTipoDocumento); ok {
+			solicitud.TipoFacturaDocumento = fiscal.TipoFacturaDocumento()
+		}
+	}
 	xmlData, err := xml.Marshal(documento)
 	if err != nil {
 		return err
 	}
 
 	var xmlToSend = xmlData
+	if b.request.SolicitudRecepcionFactura.CodigoModalidad == ModalidadElectronica &&
+		signer == nil && b.firmaElectronicaRequerida {
+		return ErrFirmaElectronicaRequerida
+	}
 
 	if signer != nil {
 		var err error

--- a/pkg/models/factura_tipo_documento_test.go
+++ b/pkg/models/factura_tipo_documento_test.go
@@ -1,0 +1,60 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/ron86i/go-siat/v2"
+	"github.com/ron86i/go-siat/v2/pkg/models/invoices"
+)
+
+func TestBuildersFacturaDefinenTipoFiscalPredeterminado(t *testing.T) {
+	casos := []struct {
+		nombre   string
+		factura  interface{ TipoFacturaDocumento() int }
+		esperado int
+	}{
+		{"compra y venta", invoices.NewCompraVentaBuilder().Build(), siat.TipoFacturaConDerechoCreditoFiscal},
+		{"exportación", invoices.NewComercialExportacionBuilder().Build(), siat.TipoFacturaSinDerechoCreditoFiscal},
+		{"turismo", invoices.NewTurismoHospedajeBuilder().Build(), siat.TipoFacturaSinDerechoCreditoFiscal},
+		{"tasa cero", invoices.NewTasaCeroBuilder().Build(), siat.TipoFacturaSinDerechoCreditoFiscal},
+		{"hotel", invoices.NewHotelBuilder().Build(), siat.TipoFacturaConDerechoCreditoFiscal},
+	}
+	for _, caso := range casos {
+		t.Run(caso.nombre, func(t *testing.T) {
+			if obtenido := caso.factura.TipoFacturaDocumento(); obtenido != caso.esperado {
+				t.Fatalf("tipo = %d; se esperaba %d", obtenido, caso.esperado)
+			}
+		})
+	}
+}
+
+func TestBuilderFacturaPermiteSobrescribirTipoFiscal(t *testing.T) {
+	casos := []struct {
+		nombre   string
+		factura  interface{ TipoFacturaDocumento() int }
+		esperado int
+	}{
+		{
+			nombre: "builder con configuración propia",
+			factura: invoices.NewTasaCeroBuilder().
+				WithTipoFacturaDocumento(siat.TipoFacturaConDerechoCreditoFiscal).
+				Build(),
+			esperado: siat.TipoFacturaConDerechoCreditoFiscal,
+		},
+		{
+			nombre: "builder centralizado",
+			factura: invoices.NewLibreConsignacionBuilder().
+				WithTipoFacturaDocumento(siat.TipoFacturaConDerechoCreditoFiscal).
+				Build(),
+			esperado: siat.TipoFacturaConDerechoCreditoFiscal,
+		},
+	}
+
+	for _, caso := range casos {
+		t.Run(caso.nombre, func(t *testing.T) {
+			if obtenido := caso.factura.TipoFacturaDocumento(); obtenido != caso.esperado {
+				t.Fatalf("tipo = %d; se esperaba %d", obtenido, caso.esperado)
+			}
+		})
+	}
+}

--- a/pkg/models/facturacion.go
+++ b/pkg/models/facturacion.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"time"
 
@@ -15,6 +16,24 @@ import (
 // XMLSigner define la interfaz para realizar la firma de documentos XML
 type XMLSigner interface {
 	SignXML(xmlBytes []byte) ([]byte, error)
+}
+
+// ErrFirmaElectronicaRequerida indica que se intentó preparar una factura
+// electrónica sin el firmador XML configurado en modo estricto.
+var ErrFirmaElectronicaRequerida = errors.New("se requiere un firmador XML para facturación electrónica")
+
+// FacturaConTipoDocumento expone el tipo fiscal predeterminado definido por
+// el builder de una factura. No forma parte del XML del documento: se usa al
+// construir la solicitud SOAP de recepción.
+type FacturaConTipoDocumento interface {
+	TipoFacturaDocumento() int
+}
+
+// FacturaConMetadatos expone la información fiscal completa del documento.
+// Los servicios sólo consumen estos valores y no aplican reglas por sector.
+type FacturaConMetadatos interface {
+	FacturaConTipoDocumento
+	CodigoDocumentoSector() int
 }
 
 // --- Interfaces opacas de Facturación ---
@@ -153,7 +172,11 @@ func (b *AnulacionFacturaBuilder) Build() AnulacionFactura {
 
 // RecepcionFacturaBuilder
 type RecepcionFacturaBuilder struct {
-	request *facturacion.RecepcionFactura
+	request                   *facturacion.RecepcionFactura
+	xmlPreparado              []byte
+	hashArchivo               string
+	xmlIndentado              bool
+	firmaElectronicaRequerida bool
 }
 
 func NewRecepcionFacturaBuilder() *RecepcionFacturaBuilder {
@@ -212,10 +235,51 @@ func (b *RecepcionFacturaBuilder) WithHashArchivo(hashArchivo string) *Recepcion
 	return b
 }
 
+// WithXMLIndentado conserva una representación legible del documento. Debe
+// activarse antes de WithFactura: la indentación forma parte del XML firmado.
+func (b *RecepcionFacturaBuilder) WithXMLIndentado() *RecepcionFacturaBuilder {
+	b.xmlIndentado = true
+	return b
+}
+
+// WithFirmaElectronicaRequerida exige un XMLSigner cuando la modalidad sea
+// electrónica. No afecta la modalidad computarizada ni el comportamiento
+// existente mientras no se invoque explícitamente.
+func (b *RecepcionFacturaBuilder) WithFirmaElectronicaRequerida() *RecepcionFacturaBuilder {
+	b.firmaElectronicaRequerida = true
+	return b
+}
+
+// WithDocumentoFiscal es la alternativa tipada a WithFactura. Garantiza en
+// compilación que el documento expone sector y tipo fiscal.
+func (b *RecepcionFacturaBuilder) WithDocumentoFiscal(documento FacturaConMetadatos, signer XMLSigner) error {
+	return b.WithFactura(documento, signer)
+}
+
 // WithFactura serializa, firma (si es electrónica), comprime y calcula el hash de la factura automáticamente,
 // mapeando los valores obtenidos en los campos Archivo y HashArchivo de la solicitud.
 func (b *RecepcionFacturaBuilder) WithFactura(factura any, signer XMLSigner) error {
-	xmlData, err := xml.Marshal(factura)
+	solicitud := &b.request.SolicitudServicioRecepcionFactura.SolicitudRecepcion
+	if documento, ok := factura.(FacturaConMetadatos); ok {
+		if solicitud.CodigoDocumentoSector == 0 {
+			solicitud.CodigoDocumentoSector = documento.CodigoDocumentoSector()
+		}
+		if solicitud.TipoFacturaDocumento == 0 {
+			solicitud.TipoFacturaDocumento = documento.TipoFacturaDocumento()
+		}
+	} else if solicitud.TipoFacturaDocumento == 0 {
+		if documento, ok := factura.(FacturaConTipoDocumento); ok {
+			solicitud.TipoFacturaDocumento = documento.TipoFacturaDocumento()
+		}
+	}
+	var xmlData []byte
+	var err error
+	if b.xmlIndentado {
+		xmlData, err = xml.MarshalIndent(factura, "", "    ")
+		xmlData = append([]byte(xml.Header), xmlData...)
+	} else {
+		xmlData, err = xml.Marshal(factura)
+	}
 	if err != nil {
 		return err
 	}
@@ -225,6 +289,9 @@ func (b *RecepcionFacturaBuilder) WithFactura(factura any, signer XMLSigner) err
 	if b.request.SolicitudServicioRecepcionFactura.CodigoModalidad == ModalidadElectronica {
 		signRequired = true
 	}
+	if signRequired && signer == nil && b.firmaElectronicaRequerida {
+		return ErrFirmaElectronicaRequerida
+	}
 
 	if signRequired && signer != nil {
 		var err error
@@ -233,6 +300,9 @@ func (b *RecepcionFacturaBuilder) WithFactura(factura any, signer XMLSigner) err
 			return err
 		}
 	}
+	if b.xmlIndentado && !bytes.HasPrefix(xmlToSend, []byte("<?xml")) {
+		xmlToSend = append([]byte(xml.Header), xmlToSend...)
+	}
 
 	hashString, encodedArchivo, err := utils.CompressAndHash(xmlToSend)
 	if err != nil {
@@ -240,7 +310,19 @@ func (b *RecepcionFacturaBuilder) WithFactura(factura any, signer XMLSigner) err
 	}
 	b.request.SolicitudServicioRecepcionFactura.Archivo = encodedArchivo
 	b.request.SolicitudServicioRecepcionFactura.HashArchivo = hashString
+	b.xmlPreparado = append(b.xmlPreparado[:0], xmlToSend...)
+	b.hashArchivo = hashString
 	return nil
+}
+
+// XMLPreparado devuelve una copia del XML firmado (o el XML computarizado) y
+// el hash exacto incluidos en la recepción SIAT. Sólo está disponible después
+// de invocar WithFactura.
+func (b *RecepcionFacturaBuilder) XMLPreparado() ([]byte, string, bool) {
+	if len(b.xmlPreparado) == 0 || b.hashArchivo == "" {
+		return nil, "", false
+	}
+	return append([]byte(nil), b.xmlPreparado...), b.hashArchivo, true
 }
 
 func (b *RecepcionFacturaBuilder) WithCodigoModalidad(codigoModalidad int) *RecepcionFacturaBuilder {

--- a/pkg/models/facturacion_xml_test.go
+++ b/pkg/models/facturacion_xml_test.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+func TestRecepcionFacturaBuilderConservaXMLIndentado(t *testing.T) {
+	type facturaPrueba struct {
+		XMLName xml.Name `xml:"facturaPrueba"`
+		Nombre  string   `xml:"nombre"`
+	}
+	builder := NewRecepcionFacturaBuilder().
+		WithCodigoModalidad(ModalidadComputarizada).
+		WithXMLIndentado()
+	if err := builder.WithFactura(facturaPrueba{Nombre: "Falmus"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	xmlPreparado, _, disponible := builder.XMLPreparado()
+	if !disponible {
+		t.Fatal("XML preparado no disponible")
+	}
+	contenido := string(xmlPreparado)
+	if !strings.HasPrefix(contenido, xml.Header) || !strings.Contains(contenido, "\n    <nombre>Falmus</nombre>\n") {
+		t.Fatalf("XML no quedó indentado: %q", contenido)
+	}
+}

--- a/pkg/models/invoices/alcanzada_ice.go
+++ b/pkg/models/invoices/alcanzada_ice.go
@@ -16,6 +16,7 @@ import (
 // AlcanzadaIce representa la estructura completa de una factura Sector 14
 // lista para ser procesada.
 type AlcanzadaIce struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaAlcanzadaIce]
 }
 
@@ -32,6 +33,7 @@ type AlcanzadaIceDetalle struct {
 // NewAlcanzadaIceBuilder inicia el proceso de construcción de la factura.
 func NewAlcanzadaIceBuilder() *alcanzadaIceBuilder {
 	return &alcanzadaIceBuilder{
+		metadatos: models.NuevosMetadatosFactura(14),
 		factura: &documents.FacturaAlcanzadaIce{
 			XMLName:           xml.Name{Local: "facturaElectronicaAlcanzadaIce"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewAlcanzadaIceDetalleBuilder() *alcanzadaIceDetalleBuilder {
 }
 
 type alcanzadaIceBuilder struct {
-	factura *documents.FacturaAlcanzadaIce
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaAlcanzadaIce
 }
 
 func (b *alcanzadaIceBuilder) WithCabecera(req AlcanzadaIceCabecera) *alcanzadaIceBuilder {
@@ -87,7 +90,7 @@ func (b *alcanzadaIceBuilder) WithModalidad(tipo int) *alcanzadaIceBuilder {
 }
 
 func (b *alcanzadaIceBuilder) Build() AlcanzadaIce {
-	return AlcanzadaIce{models.NewRequestWrapper(b.factura)}
+	return AlcanzadaIce{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type alcanzadaIceCabeceraBuilder struct {

--- a/pkg/models/invoices/alquiler_bien_inmueble.go
+++ b/pkg/models/invoices/alquiler_bien_inmueble.go
@@ -16,6 +16,7 @@ import (
 // AlquilerBienInmueble representa la estructura completa de una factura de Alquiler de Bienes Inmuebles lista para ser procesada.
 type AlquilerBienInmueble struct {
 	models.RequestWrapper[documents.FacturaAlquilerBienInmueble]
+	models.MetadatosFactura
 }
 
 // AlquilerBienInmuebleCabecera representa la sección de cabecera de una factura de Alquiler de Bienes Inmuebles.
@@ -31,6 +32,7 @@ type AlquilerBienInmuebleDetalle struct {
 // NewAlquilerBienInmuebleBuilder inicia el proceso de construcción de una Factura de Alquiler de Bienes Inmuebles.
 func NewAlquilerBienInmuebleBuilder() *alquilerBienInmuebleBuilder {
 	return &alquilerBienInmuebleBuilder{
+		metadatos: models.NuevosMetadatosFactura(2),
 		factura: &documents.FacturaAlquilerBienInmueble{
 			XMLName:           xml.Name{Local: "facturaElectronicaAlquilerBienInmueble"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,14 @@ func NewAlquilerBienInmuebleDetalleBuilder() *alquilerBienInmuebleDetalleBuilder
 }
 
 type alquilerBienInmuebleBuilder struct {
-	factura *documents.FacturaAlquilerBienInmueble
+	factura   *documents.FacturaAlquilerBienInmueble
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de alquiler.
+func (b *alquilerBienInmuebleBuilder) WithTipoFacturaDocumento(tipo int) *alquilerBienInmuebleBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *alquilerBienInmuebleBuilder) WithCabecera(req AlquilerBienInmuebleCabecera) *alquilerBienInmuebleBuilder {
@@ -86,7 +95,7 @@ func (b *alquilerBienInmuebleBuilder) WithModalidad(tipo int) *alquilerBienInmue
 }
 
 func (b *alquilerBienInmuebleBuilder) Build() AlquilerBienInmueble {
-	return AlquilerBienInmueble{models.NewRequestWrapper(b.factura)}
+	return AlquilerBienInmueble{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type alquilerBienInmuebleCabeceraBuilder struct {

--- a/pkg/models/invoices/alquiler_zona_franca.go
+++ b/pkg/models/invoices/alquiler_zona_franca.go
@@ -15,6 +15,7 @@ import (
 
 // AlquilerZF representa la estructura completa de una factura de Alquiler ZF lista para ser procesada.
 type AlquilerZF struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaAlquilerZF]
 }
 
@@ -31,6 +32,7 @@ type AlquilerZFDetalle struct {
 // NewAlquilerZFBuilder inicia el proceso de construcción de una Factura de Alquiler ZF.
 func NewAlquilerZFBuilder() *alquilerZFBuilder {
 	return &alquilerZFBuilder{
+		metadatos: models.NuevosMetadatosFactura(42),
 		factura: &documents.FacturaAlquilerZF{
 			XMLName:           xml.Name{Local: "facturaElectronicaAlquilerZF"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewAlquilerZFDetalleBuilder() *alquilerZFDetalleBuilder {
 }
 
 type alquilerZFBuilder struct {
-	factura *documents.FacturaAlquilerZF
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaAlquilerZF
 }
 
 func (b *alquilerZFBuilder) WithCabecera(req AlquilerZFCabecera) *alquilerZFBuilder {
@@ -87,7 +90,7 @@ func (b *alquilerZFBuilder) WithModalidad(tipo int) *alquilerZFBuilder {
 }
 
 func (b *alquilerZFBuilder) Build() AlquilerZF {
-	return AlquilerZF{models.NewRequestWrapper(b.factura)}
+	return AlquilerZF{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type alquilerZFCabeceraBuilder struct {

--- a/pkg/models/invoices/biodiesel.go
+++ b/pkg/models/invoices/biodiesel.go
@@ -15,6 +15,7 @@ import (
 
 // Biodiesel representa la estructura completa de una factura de Biodiesel lista para ser procesada.
 type Biodiesel struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaBiodiesel]
 }
 
@@ -31,6 +32,7 @@ type BiodieselDetalle struct {
 // NewBiodieselBuilder inicia el proceso de construcción de una Factura de Biodiesel.
 func NewBiodieselBuilder() *biodieselBuilder {
 	return &biodieselBuilder{
+		metadatos: models.NuevosMetadatosFactura(54),
 		factura: &documents.FacturaBiodiesel{
 			XMLName:           xml.Name{Local: "facturaElectronicaBiodiesel"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewBiodieselDetalleBuilder() *biodieselDetalleBuilder {
 }
 
 type biodieselBuilder struct {
-	factura *documents.FacturaBiodiesel
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaBiodiesel
 }
 
 func (b *biodieselBuilder) WithCabecera(req BiodieselCabecera) *biodieselBuilder {
@@ -87,7 +90,7 @@ func (b *biodieselBuilder) WithModalidad(tipo int) *biodieselBuilder {
 }
 
 func (b *biodieselBuilder) Build() Biodiesel {
-	return Biodiesel{models.NewRequestWrapper(b.factura)}
+	return Biodiesel{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type biodieselCabeceraBuilder struct {

--- a/pkg/models/invoices/boleto_aereo.go
+++ b/pkg/models/invoices/boleto_aereo.go
@@ -14,6 +14,7 @@ import (
 // BoletoAereo representa la estructura completa de una factura de boleto aéreo lista para ser procesada.
 // Esta estructura encapsula la factura del sector 30 para su uso en los servicios del SDK.
 type BoletoAereo struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaBoletoAereo]
 }
 
@@ -24,12 +25,14 @@ type BoletoAereoCabecera struct {
 
 // boletoAereoBuilder permite la construcción fluida de una factura de Boleto Aéreo.
 type boletoAereoBuilder struct {
-	factura *documents.FacturaBoletoAereo
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaBoletoAereo
 }
 
 // NewBoletoAereoBuilder inicializa un nuevo constructor para una factura de Boleto Aéreo.
 func NewBoletoAereoBuilder() *boletoAereoBuilder {
 	return &boletoAereoBuilder{
+		metadatos: models.NuevosMetadatosFactura(30),
 		factura: &documents.FacturaBoletoAereo{
 			XMLName:           xml.Name{Local: "facturaElectronicaBoletoAereo"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -61,7 +64,7 @@ func (b *boletoAereoBuilder) WithCabecera(req BoletoAereoCabecera) *boletoAereoB
 
 // Build finaliza la construcción y retorna el objeto BoletoAereo para su envío.
 func (b *boletoAereoBuilder) Build() BoletoAereo {
-	return BoletoAereo{models.NewRequestWrapper(b.factura)}
+	return BoletoAereo{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // --- Cabecera Builder ---

--- a/pkg/models/invoices/comercial_exportacion.go
+++ b/pkg/models/invoices/comercial_exportacion.go
@@ -19,6 +19,7 @@ import (
 // de exportación lista para ser procesada.
 type ComercialExportacion struct {
 	models.RequestWrapper[documents.FacturaComercialExportacion]
+	models.MetadatosFactura
 }
 
 // ComercialExportacionCabecera representa la sección de cabecera de la factura.
@@ -34,6 +35,7 @@ type ComercialExportacionDetalle struct {
 // NewComercialExportacionBuilder inicia el proceso de construcción de la factura.
 func NewComercialExportacionBuilder() *comercialExportacionBuilder {
 	return &comercialExportacionBuilder{
+		metadatos: models.NuevosMetadatosFactura(3),
 		factura: &documents.FacturaComercialExportacion{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercialExportacion"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -60,7 +62,14 @@ func NewComercialExportacionDetalleBuilder() *comercialExportacionDetalleBuilder
 }
 
 type comercialExportacionBuilder struct {
-	factura *documents.FacturaComercialExportacion
+	factura   *documents.FacturaComercialExportacion
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de exportación.
+func (b *comercialExportacionBuilder) WithTipoFacturaDocumento(tipo int) *comercialExportacionBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *comercialExportacionBuilder) WithCabecera(req ComercialExportacionCabecera) *comercialExportacionBuilder {
@@ -90,7 +99,7 @@ func (b *comercialExportacionBuilder) WithModalidad(tipo int) *comercialExportac
 }
 
 func (b *comercialExportacionBuilder) Build() ComercialExportacion {
-	return ComercialExportacion{models.NewRequestWrapper(b.factura)}
+	return ComercialExportacion{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercialExportacionCabeceraBuilder struct {

--- a/pkg/models/invoices/comercial_exportacion_hidrocarburos.go
+++ b/pkg/models/invoices/comercial_exportacion_hidrocarburos.go
@@ -16,6 +16,7 @@ import (
 
 // ComercialExportacionHidro representa la estructura completa de una factura de Comercial Exportación Hidrocarburos lista para ser procesada.
 type ComercialExportacionHidro struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercialExportacionHidro]
 }
 
@@ -32,6 +33,7 @@ type ComercialExportacionHidroDetalle struct {
 // NewComercialExportacionHidroBuilder inicia el proceso de construcción de una Factura de Comercial Exportación Hidrocarburos.
 func NewComercialExportacionHidroBuilder() *comercialExportacionHidroBuilder {
 	return &comercialExportacionHidroBuilder{
+		metadatos: models.NuevosMetadatosFactura(43),
 		factura: &documents.FacturaComercialExportacionHidro{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercialExportacionHidro"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewComercialExportacionHidroDetalleBuilder() *comercialExportacionHidroDeta
 }
 
 type comercialExportacionHidroBuilder struct {
-	factura *documents.FacturaComercialExportacionHidro
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercialExportacionHidro
 }
 
 func (b *comercialExportacionHidroBuilder) WithCabecera(req ComercialExportacionHidroCabecera) *comercialExportacionHidroBuilder {
@@ -87,7 +90,7 @@ func (b *comercialExportacionHidroBuilder) WithModalidad(tipo int) *comercialExp
 }
 
 func (b *comercialExportacionHidroBuilder) Build() ComercialExportacionHidro {
-	return ComercialExportacionHidro{models.NewRequestWrapper(b.factura)}
+	return ComercialExportacionHidro{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercialExportacionHidroCabeceraBuilder struct {

--- a/pkg/models/invoices/comercial_exportacion_minera.go
+++ b/pkg/models/invoices/comercial_exportacion_minera.go
@@ -16,6 +16,7 @@ import (
 
 // ComercialExportacionMinera representa la estructura completa de una factura de Comercial Exportación Minera lista para ser procesada.
 type ComercialExportacionMinera struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercialExportacionMinera]
 }
 
@@ -32,6 +33,7 @@ type ComercialExportacionMineraDetalle struct {
 // NewComercialExportacionMineraBuilder inicia el proceso de construcción de una Factura de Comercial Exportación Minera.
 func NewComercialExportacionMineraBuilder() *comercialExportacionMineraBuilder {
 	return &comercialExportacionMineraBuilder{
+		metadatos: models.NuevosMetadatosFactura(20),
 		factura: &documents.FacturaComercialExportacionMinera{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercialExportacionMinera"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewComercialExportacionMineraDetalleBuilder() *comercialExportacionMineraDe
 }
 
 type comercialExportacionMineraBuilder struct {
-	factura *documents.FacturaComercialExportacionMinera
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercialExportacionMinera
 }
 
 func (b *comercialExportacionMineraBuilder) WithCabecera(req ComercialExportacionMineraCabecera) *comercialExportacionMineraBuilder {
@@ -87,7 +90,7 @@ func (b *comercialExportacionMineraBuilder) WithModalidad(tipo int) *comercialEx
 }
 
 func (b *comercialExportacionMineraBuilder) Build() ComercialExportacionMinera {
-	return ComercialExportacionMinera{models.NewRequestWrapper(b.factura)}
+	return ComercialExportacionMinera{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercialExportacionMineraCabeceraBuilder struct {

--- a/pkg/models/invoices/comercial_exportacion_punto_venta.go
+++ b/pkg/models/invoices/comercial_exportacion_punto_venta.go
@@ -16,6 +16,7 @@ import (
 
 // ComercialExportacionPVenta representa la estructura completa de una factura PVenta lista para ser procesada.
 type ComercialExportacionPVenta struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercialExportacionPVenta]
 }
 
@@ -32,6 +33,7 @@ type ComercialExportacionPVentaDetalle struct {
 // NewComercialExportacionPVentaBuilder inicia el proceso de construcción de una Factura PVenta.
 func NewComercialExportacionPVentaBuilder() *comercialExportacionPVentaBuilder {
 	return &comercialExportacionPVentaBuilder{
+		metadatos: models.NuevosMetadatosFactura(45),
 		factura: &documents.FacturaComercialExportacionPVenta{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercialExportacionPVenta"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -58,7 +60,8 @@ func NewComercialExportacionPVentaDetalleBuilder() *comercialExportacionPVentaDe
 }
 
 type comercialExportacionPVentaBuilder struct {
-	factura *documents.FacturaComercialExportacionPVenta
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercialExportacionPVenta
 }
 
 func (b *comercialExportacionPVentaBuilder) WithCabecera(req ComercialExportacionPVentaCabecera) *comercialExportacionPVentaBuilder {
@@ -88,7 +91,7 @@ func (b *comercialExportacionPVentaBuilder) WithModalidad(tipo int) *comercialEx
 }
 
 func (b *comercialExportacionPVentaBuilder) Build() ComercialExportacionPVenta {
-	return ComercialExportacionPVenta{models.NewRequestWrapper(b.factura)}
+	return ComercialExportacionPVenta{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercialExportacionPVentaCabeceraBuilder struct {

--- a/pkg/models/invoices/comercial_exportacion_servicio.go
+++ b/pkg/models/invoices/comercial_exportacion_servicio.go
@@ -16,6 +16,7 @@ import (
 // ComercialExportacionServicio representa la estructura completa de una factura comercial
 // de exportación de servicios lista para ser procesada.
 type ComercialExportacionServicio struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercialExportacionServicio]
 }
 
@@ -32,6 +33,7 @@ type ComercialExportacionServicioDetalle struct {
 // NewComercialExportacionServicioBuilder inicia el proceso de construcción de la factura.
 func NewComercialExportacionServicioBuilder() *comercialExportacionServicioBuilder {
 	return &comercialExportacionServicioBuilder{
+		metadatos: models.NuevosMetadatosFactura(28),
 		factura: &documents.FacturaComercialExportacionServicio{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercialExportacionServicio"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -60,7 +62,8 @@ func NewComercialExportacionServicioDetalleBuilder() *comercialExportacionServic
 }
 
 type comercialExportacionServicioBuilder struct {
-	factura *documents.FacturaComercialExportacionServicio
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercialExportacionServicio
 }
 
 func (b *comercialExportacionServicioBuilder) WithCabecera(req ComercialExportacionServicioCabecera) *comercialExportacionServicioBuilder {
@@ -90,7 +93,7 @@ func (b *comercialExportacionServicioBuilder) WithModalidad(tipo int) *comercial
 }
 
 func (b *comercialExportacionServicioBuilder) Build() ComercialExportacionServicio {
-	return ComercialExportacionServicio{models.NewRequestWrapper(b.factura)}
+	return ComercialExportacionServicio{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercialExportacionServicioCabeceraBuilder struct {

--- a/pkg/models/invoices/comercializacion_gn_glp.go
+++ b/pkg/models/invoices/comercializacion_gn_glp.go
@@ -15,6 +15,7 @@ import (
 
 // ComercializacionGnGlp representa la estructura completa de una factura de Comercialización de GN y GLP lista para ser procesada.
 type ComercializacionGnGlp struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercializacionGnGlp]
 }
 
@@ -31,6 +32,7 @@ type ComercializacionGnGlpDetalle struct {
 // NewComercializacionGnGlpBuilder inicia el proceso de construcción de una Factura de Comercialización de GN y GLP.
 func NewComercializacionGnGlpBuilder() *comercializacionGnGlpBuilder {
 	return &comercializacionGnGlpBuilder{
+		metadatos: models.NuevosMetadatosFactura(39),
 		factura: &documents.FacturaComercializacionGnGlp{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercializacionGnGlp"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewComercializacionGnGlpDetalleBuilder() *comercializacionGnGlpDetalleBuild
 }
 
 type comercializacionGnGlpBuilder struct {
-	factura *documents.FacturaComercializacionGnGlp
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercializacionGnGlp
 }
 
 func (b *comercializacionGnGlpBuilder) WithCabecera(req ComercializacionGnGlpCabecera) *comercializacionGnGlpBuilder {
@@ -86,7 +89,7 @@ func (b *comercializacionGnGlpBuilder) WithModalidad(tipo int) *comercializacion
 }
 
 func (b *comercializacionGnGlpBuilder) Build() ComercializacionGnGlp {
-	return ComercializacionGnGlp{models.NewRequestWrapper(b.factura)}
+	return ComercializacionGnGlp{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercializacionGnGlpCabeceraBuilder struct {

--- a/pkg/models/invoices/comercializacion_gnv.go
+++ b/pkg/models/invoices/comercializacion_gnv.go
@@ -15,6 +15,7 @@ import (
 
 // ComercializacionGnv representa la estructura completa de una factura de Comercialización de GNV lista para ser procesada.
 type ComercializacionGnv struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercializacionGnv]
 }
 
@@ -31,6 +32,7 @@ type ComercializacionGnvDetalle struct {
 // NewComercializacionGnvBuilder inicia el proceso de construcción de una Factura de Comercialización de GNV.
 func NewComercializacionGnvBuilder() *comercializacionGnvBuilder {
 	return &comercializacionGnvBuilder{
+		metadatos: models.NuevosMetadatosFactura(37),
 		factura: &documents.FacturaComercializacionGnv{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercializacionGnv"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewComercializacionGnvDetalleBuilder() *comercializacionGnvDetalleBuilder {
 }
 
 type comercializacionGnvBuilder struct {
-	factura *documents.FacturaComercializacionGnv
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercializacionGnv
 }
 
 func (b *comercializacionGnvBuilder) WithCabecera(req ComercializacionGnvCabecera) *comercializacionGnvBuilder {
@@ -86,7 +89,7 @@ func (b *comercializacionGnvBuilder) WithModalidad(tipo int) *comercializacionGn
 }
 
 func (b *comercializacionGnvBuilder) Build() ComercializacionGnv {
-	return ComercializacionGnv{models.NewRequestWrapper(b.factura)}
+	return ComercializacionGnv{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercializacionGnvCabeceraBuilder struct {

--- a/pkg/models/invoices/comercializacion_hidrocarburos.go
+++ b/pkg/models/invoices/comercializacion_hidrocarburos.go
@@ -15,6 +15,7 @@ import (
 
 // ComercializacionHidro representa la estructura completa de una factura de Comercialización de Hidrocarburos lista para ser procesada.
 type ComercializacionHidro struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaComercializacionHidro]
 }
 
@@ -31,6 +32,7 @@ type ComercializacionHidroDetalle struct {
 // NewComercializacionHidroBuilder inicia el proceso de construcción de una Factura de Comercialización de Hidrocarburos.
 func NewComercializacionHidroBuilder() *comercializacionHidroBuilder {
 	return &comercializacionHidroBuilder{
+		metadatos: models.NuevosMetadatosFactura(12),
 		factura: &documents.FacturaComercializacionHidro{
 			XMLName:           xml.Name{Local: "facturaElectronicaComercializacionHidrocarburo"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewComercializacionHidroDetalleBuilder() *comercializacionHidroDetalleBuild
 }
 
 type comercializacionHidroBuilder struct {
-	factura *documents.FacturaComercializacionHidro
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaComercializacionHidro
 }
 
 func (b *comercializacionHidroBuilder) WithCabecera(req ComercializacionHidroCabecera) *comercializacionHidroBuilder {
@@ -86,7 +89,7 @@ func (b *comercializacionHidroBuilder) WithModalidad(tipo int) *comercializacion
 }
 
 func (b *comercializacionHidroBuilder) Build() ComercializacionHidro {
-	return ComercializacionHidro{models.NewRequestWrapper(b.factura)}
+	return ComercializacionHidro{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type comercializacionHidroCabeceraBuilder struct {

--- a/pkg/models/invoices/compra_venta.go
+++ b/pkg/models/invoices/compra_venta.go
@@ -15,6 +15,7 @@ import (
 // CompraVenta representa la estructura completa de una factura lista para ser procesada.
 type CompraVenta struct {
 	models.RequestWrapper[documents.FacturaCompraVenta]
+	models.MetadatosFactura
 }
 
 // CompraVentaCabecera representa la sección de cabecera de una factura de compra y venta.
@@ -33,6 +34,7 @@ type CompraVentaDetalle struct {
 // Por defecto, la factura se configura para ser emitida electrónica.
 func NewCompraVentaBuilder() *compraVentaBuilder {
 	return &compraVentaBuilder{
+		metadatos: models.NuevosMetadatosFactura(1),
 		factura: &documents.FacturaCompraVenta{
 			XMLName:           xml.Name{Local: "facturaElectronicaCompraVenta"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -60,7 +62,14 @@ func NewCompraVentaDetalleBuilder() *detalleBuilder {
 }
 
 type compraVentaBuilder struct {
-	factura *documents.FacturaCompraVenta
+	factura   *documents.FacturaCompraVenta
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de compra y venta.
+func (b *compraVentaBuilder) WithTipoFacturaDocumento(tipo int) *compraVentaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 // WithCabecera asocia la cabecera construida previamente a la factura.
@@ -94,7 +103,7 @@ func (b *compraVentaBuilder) WithModalidad(tipo int) *compraVentaBuilder {
 
 // Build finaliza la construcción y retorna la estructura opaca lista para ser firmada y enviada.
 func (b *compraVentaBuilder) Build() CompraVenta {
-	return CompraVenta{models.NewRequestWrapper(b.factura)}
+	return CompraVenta{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // compraVentaCabeceraBuilder ayuda a configurar la cabecera de la factura de compra y venta.

--- a/pkg/models/invoices/compra_venta_bonificaciones.go
+++ b/pkg/models/invoices/compra_venta_bonificaciones.go
@@ -15,6 +15,7 @@ import (
 // CompraVentaBonificaciones representa una factura de compra-venta con bonificaciones lista para procesar.
 type CompraVentaBonificaciones struct {
 	models.RequestWrapper[documents.FacturaCompraVentaBonificaciones]
+	models.MetadatosFactura
 }
 
 // CompraVentaBonificacionesCabecera representa la cabecera de una factura de bonificaciones.
@@ -30,6 +31,7 @@ type CompraVentaBonificacionesDetalle struct {
 // NewCompraVentaBonificacionesBuilder inicia la construcción de una factura de compra-venta con bonificaciones.
 func NewCompraVentaBonificacionesBuilder() *compraVentaBonificacionesBuilder {
 	return &compraVentaBonificacionesBuilder{
+		metadatos: models.NuevosMetadatosFactura(35),
 		factura: &documents.FacturaCompraVentaBonificaciones{
 			XMLName:           xml.Name{Local: "facturaElectronicaCompraVentaBon"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,14 @@ func NewCompraVentaBonificacionesDetalleBuilder() *detalleBonificacionesBuilder 
 // --- Builder Factura Bonificaciones ---
 
 type compraVentaBonificacionesBuilder struct {
-	factura *documents.FacturaCompraVentaBonificaciones
+	factura   *documents.FacturaCompraVentaBonificaciones
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de bonificaciones.
+func (b *compraVentaBonificacionesBuilder) WithTipoFacturaDocumento(tipo int) *compraVentaBonificacionesBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 // WithModalidad configura los metadatos XML según la modalidad.
@@ -88,7 +97,7 @@ func (b *compraVentaBonificacionesBuilder) AddDetalle(req CompraVentaBonificacio
 }
 
 func (b *compraVentaBonificacionesBuilder) Build() CompraVentaBonificaciones {
-	return CompraVentaBonificaciones{models.NewRequestWrapper(b.factura)}
+	return CompraVentaBonificaciones{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // --- Builder Cabecera Bonificaciones ---

--- a/pkg/models/invoices/compra_venta_tasas.go
+++ b/pkg/models/invoices/compra_venta_tasas.go
@@ -15,6 +15,7 @@ import (
 // CompraVentaTasas representa una factura de compra-venta con tasas lista para procesar.
 type CompraVentaTasas struct {
 	models.RequestWrapper[documents.FacturaCompraVentaTasas]
+	models.MetadatosFactura
 }
 
 // CompraVentaTasasCabecera representa la cabecera de una factura de tasas.
@@ -30,6 +31,7 @@ type CompraVentaTasasDetalle struct {
 // NewCompraVentaTasasBuilder inicia la construcción de una factura de compra-venta con tasas.
 func NewCompraVentaTasasBuilder() *compraVentaTasasBuilder {
 	return &compraVentaTasasBuilder{
+		metadatos: models.NuevosMetadatosFactura(41),
 		factura: &documents.FacturaCompraVentaTasas{
 			XMLName:           xml.Name{Local: "facturaElectronicaCompraVentaTasas"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,14 @@ func NewCompraVentaTasasDetalleBuilder() *detalleTasasBuilder {
 // --- Builder Factura Tasas ---
 
 type compraVentaTasasBuilder struct {
-	factura *documents.FacturaCompraVentaTasas
+	factura   *documents.FacturaCompraVentaTasas
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de tasas.
+func (b *compraVentaTasasBuilder) WithTipoFacturaDocumento(tipo int) *compraVentaTasasBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 // WithModalidad configura los metadatos XML según la modalidad.
@@ -93,7 +102,7 @@ func (b *compraVentaTasasBuilder) AddDetalle(req ...CompraVentaTasasDetalle) *co
 
 // Build finaliza la construcción y retorna la estructura opaca.
 func (b *compraVentaTasasBuilder) Build() CompraVentaTasas {
-	return CompraVentaTasas{models.NewRequestWrapper(b.factura)}
+	return CompraVentaTasas{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // --- Builder Cabecera Tasas ---

--- a/pkg/models/invoices/dutty_free.go
+++ b/pkg/models/invoices/dutty_free.go
@@ -15,6 +15,7 @@ import (
 
 // DuttyFree representa la estructura completa de una factura Dutty Free lista para ser procesada.
 type DuttyFree struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaDuttyFree]
 }
 
@@ -32,6 +33,7 @@ type DuttyFreeDetalle struct {
 // NewDuttyFree inicia el proceso de construcción de una DuttyFree.
 func NewDuttyFreeBuilder() *duttyFreeBuilder {
 	return &duttyFreeBuilder{
+		metadatos: models.NuevosMetadatosFactura(10),
 		factura: &documents.FacturaDuttyFree{
 			XMLName:           xml.Name{Local: "facturaElectronicaDuttyFree"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -60,7 +62,8 @@ func NewDuttyFreeDetalleBuilder() *duttyFreeDetalleBuilder {
 }
 
 type duttyFreeBuilder struct {
-	factura *documents.FacturaDuttyFree
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaDuttyFree
 }
 
 func (b *duttyFreeBuilder) WithCabecera(req DuttyFreeCabecera) *duttyFreeBuilder {
@@ -90,7 +93,7 @@ func (b *duttyFreeBuilder) WithModalidad(tipo int) *duttyFreeBuilder {
 }
 
 func (b *duttyFreeBuilder) Build() DuttyFree {
-	return DuttyFree{models.NewRequestWrapper(b.factura)}
+	return DuttyFree{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type duttyFreeCabeceraBuilder struct {

--- a/pkg/models/invoices/engarrafadoras.go
+++ b/pkg/models/invoices/engarrafadoras.go
@@ -15,6 +15,7 @@ import (
 
 // Engarrafadoras representa la estructura completa de una factura de engarrafadoras lista para ser procesada.
 type Engarrafadoras struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaEngarrafadoras]
 }
 
@@ -31,6 +32,7 @@ type EngarrafadorasDetalle struct {
 // NewEngarrafadoras inicia el proceso de construcción de la factura.
 func NewEngarrafadorasBuilder() *engarrafadorasBuilder {
 	return &engarrafadorasBuilder{
+		metadatos: models.NuevosMetadatosFactura(51),
 		factura: &documents.FacturaEngarrafadoras{
 			XMLName:           xml.Name{Local: "facturaElectronicaEngarrafadoras"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewEngarrafadorasDetalleBuilder() *engarrafadorasDetalleBuilder {
 }
 
 type engarrafadorasBuilder struct {
-	factura *documents.FacturaEngarrafadoras
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaEngarrafadoras
 }
 
 func (b *engarrafadorasBuilder) WithCabecera(req EngarrafadorasCabecera) *engarrafadorasBuilder {
@@ -86,7 +89,7 @@ func (b *engarrafadorasBuilder) WithModalidad(tipo int) *engarrafadorasBuilder {
 }
 
 func (b *engarrafadorasBuilder) Build() Engarrafadoras {
-	return Engarrafadoras{models.NewRequestWrapper(b.factura)}
+	return Engarrafadoras{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type engarrafadorasCabeceraBuilder struct {

--- a/pkg/models/invoices/entidad_financiera.go
+++ b/pkg/models/invoices/entidad_financiera.go
@@ -13,6 +13,7 @@ import (
 
 // EntidadFinanciera representa la estructura completa de una factura de entidad financiera lista para ser procesada.
 type EntidadFinanciera struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaEntidadFinanciera]
 }
 
@@ -27,11 +28,13 @@ type EntidadFinancieraDetalle struct {
 }
 
 type entidadFinancieraBuilder struct {
-	factura *documents.FacturaEntidadFinanciera
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaEntidadFinanciera
 }
 
 func NewEntidadFinancieraBuilder() *entidadFinancieraBuilder {
 	return &entidadFinancieraBuilder{
+		metadatos: models.NuevosMetadatosFactura(15),
 		factura: &documents.FacturaEntidadFinanciera{
 			XMLName:           xml.Name{Local: "facturaElectronicaEntidadFinanciera"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -67,7 +70,7 @@ func (b *entidadFinancieraBuilder) AddDetalle(req EntidadFinancieraDetalle) *ent
 }
 
 func (b *entidadFinancieraBuilder) Build() EntidadFinanciera {
-	return EntidadFinanciera{models.NewRequestWrapper(b.factura)}
+	return EntidadFinanciera{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // Cabecera Builder

--- a/pkg/models/invoices/hidrocarburo_alcanzada_iehd.go
+++ b/pkg/models/invoices/hidrocarburo_alcanzada_iehd.go
@@ -16,6 +16,7 @@ import (
 // HidrocarburoAlcanzadaIehd representa una factura de Hidrocarburos Alcanzada por el IEHD
 // (Sector 19) lista para ser procesada.
 type HidrocarburoAlcanzadaIehd struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaHidrocarburoAlcanzadaIehd]
 }
 
@@ -33,6 +34,7 @@ type HidrocarburoAlcanzadaIehdDetalle struct {
 // Hidrocarburos Alcanzada por el IEHD (Sector 19).
 func NewHidrocarburoAlcanzadaIehdBuilder() *hidrocarburoAlcanzadaIehdBuilder {
 	return &hidrocarburoAlcanzadaIehdBuilder{
+		metadatos: models.NuevosMetadatosFactura(19),
 		factura: &documents.FacturaHidrocarburoAlcanzadaIehd{
 			XMLName:           xml.Name{Local: "facturaElectronicaHidrocarburoAlcanzadaIehd"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -58,7 +60,8 @@ func NewHidrocarburoAlcanzadaIehdDetalleBuilder() *hidrocarburoAlcanzadaIehdDeta
 }
 
 type hidrocarburoAlcanzadaIehdBuilder struct {
-	factura *documents.FacturaHidrocarburoAlcanzadaIehd
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaHidrocarburoAlcanzadaIehd
 }
 
 func (b *hidrocarburoAlcanzadaIehdBuilder) WithCabecera(req HidrocarburoAlcanzadaIehdCabecera) *hidrocarburoAlcanzadaIehdBuilder {
@@ -88,7 +91,7 @@ func (b *hidrocarburoAlcanzadaIehdBuilder) WithModalidad(tipo int) *hidrocarburo
 }
 
 func (b *hidrocarburoAlcanzadaIehdBuilder) Build() HidrocarburoAlcanzadaIehd {
-	return HidrocarburoAlcanzadaIehd{models.NewRequestWrapper(b.factura)}
+	return HidrocarburoAlcanzadaIehd{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type hidrocarburoAlcanzadaIehdCabeceraBuilder struct {

--- a/pkg/models/invoices/hidrocarburo_no_alcanzada_iehd.go
+++ b/pkg/models/invoices/hidrocarburo_no_alcanzada_iehd.go
@@ -16,6 +16,7 @@ import (
 // HidrocarburoNoAlcanzadaIehd representa una factura de Hidrocarburos No Alcanzada por el IEHD
 // (Sector 38) lista para ser procesada.
 type HidrocarburoNoAlcanzadaIehd struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaHidrocarburoNoAlcanzadaIehd]
 }
 
@@ -33,6 +34,7 @@ type HidrocarburoNoAlcanzadaIehdDetalle struct {
 // Hidrocarburos No Alcanzada por el IEHD (Sector 38).
 func NewHidrocarburoNoAlcanzadaIehdBuilder() *hidrocarburoNoAlcanzadaIehdBuilder {
 	return &hidrocarburoNoAlcanzadaIehdBuilder{
+		metadatos: models.NuevosMetadatosFactura(38),
 		factura: &documents.FacturaHidrocarburoNoAlcanzadaIehd{
 			XMLName:           xml.Name{Local: "facturaElectronicaHidrocarburoNoAlcanzadaIehd"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -58,7 +60,8 @@ func NewHidrocarburoNoAlcanzadaIehdDetalleBuilder() *hidrocarburoNoAlcanzadaIehd
 }
 
 type hidrocarburoNoAlcanzadaIehdBuilder struct {
-	factura *documents.FacturaHidrocarburoNoAlcanzadaIehd
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaHidrocarburoNoAlcanzadaIehd
 }
 
 func (b *hidrocarburoNoAlcanzadaIehdBuilder) WithCabecera(req HidrocarburoNoAlcanzadaIehdCabecera) *hidrocarburoNoAlcanzadaIehdBuilder {
@@ -88,7 +91,7 @@ func (b *hidrocarburoNoAlcanzadaIehdBuilder) WithModalidad(tipo int) *hidrocarbu
 }
 
 func (b *hidrocarburoNoAlcanzadaIehdBuilder) Build() HidrocarburoNoAlcanzadaIehd {
-	return HidrocarburoNoAlcanzadaIehd{models.NewRequestWrapper(b.factura)}
+	return HidrocarburoNoAlcanzadaIehd{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type hidrocarburoNoAlcanzadaIehdCabeceraBuilder struct {

--- a/pkg/models/invoices/hospital_clinica.go
+++ b/pkg/models/invoices/hospital_clinica.go
@@ -16,6 +16,7 @@ import (
 // HospitalClinica representa la estructura completa de una factura de Hospital o Clínica lista para ser procesada.
 type HospitalClinica struct {
 	models.RequestWrapper[documents.FacturaHospitalClinica]
+	models.MetadatosFactura
 }
 
 // HospitalClinicaCabecera representa la sección de cabecera de la factura.
@@ -31,6 +32,7 @@ type HospitalClinicaDetalle struct {
 // NewHospitalClinicaBuilder inicia el proceso de construcción de la factura.
 func NewHospitalClinicaBuilder() *hospitalClinicaBuilder {
 	return &hospitalClinicaBuilder{
+		metadatos: models.NuevosMetadatosFactura(17),
 		factura: &documents.FacturaHospitalClinica{
 			XMLName:           xml.Name{Local: "facturaElectronicaHospitalClinica"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,14 @@ func NewHospitalClinicaDetalleBuilder() *hospitalClinicaDetalleBuilder {
 }
 
 type hospitalClinicaBuilder struct {
-	factura *documents.FacturaHospitalClinica
+	factura   *documents.FacturaHospitalClinica
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de hospital o clínica.
+func (b *hospitalClinicaBuilder) WithTipoFacturaDocumento(tipo int) *hospitalClinicaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *hospitalClinicaBuilder) WithCabecera(req HospitalClinicaCabecera) *hospitalClinicaBuilder {
@@ -86,7 +95,7 @@ func (b *hospitalClinicaBuilder) WithModalidad(tipo int) *hospitalClinicaBuilder
 }
 
 func (b *hospitalClinicaBuilder) Build() HospitalClinica {
-	return HospitalClinica{models.NewRequestWrapper(b.factura)}
+	return HospitalClinica{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type hospitalClinicaCabeceraBuilder struct {

--- a/pkg/models/invoices/hospital_clinica_zona_franca.go
+++ b/pkg/models/invoices/hospital_clinica_zona_franca.go
@@ -15,6 +15,7 @@ import (
 
 // HospitalClinicaZF representa la estructura completa de una factura Hospital Clínica Zona Franca.
 type HospitalClinicaZF struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaHospitalClinicaZF]
 }
 
@@ -31,6 +32,7 @@ type HospitalClinicaZFDetalle struct {
 // NewHospitalClinicaZFBuilder inicia el proceso de construcción.
 func NewHospitalClinicaZFBuilder() *hospitalClinicaZFBuilder {
 	return &hospitalClinicaZFBuilder{
+		metadatos: models.NuevosMetadatosFactura(50),
 		factura: &documents.FacturaHospitalClinicaZF{
 			XMLName:           xml.Name{Local: "facturaElectronicaHospitalClinicaZF"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewHospitalClinicaZonaFrancaDetalleBuilder() *hospitalClinicaZFDetalleBuild
 }
 
 type hospitalClinicaZFBuilder struct {
-	factura *documents.FacturaHospitalClinicaZF
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaHospitalClinicaZF
 }
 
 func (b *hospitalClinicaZFBuilder) WithCabecera(req HospitalClinicaZFCabecera) *hospitalClinicaZFBuilder {
@@ -87,7 +90,7 @@ func (b *hospitalClinicaZFBuilder) WithModalidad(tipo int) *hospitalClinicaZFBui
 }
 
 func (b *hospitalClinicaZFBuilder) Build() HospitalClinicaZF {
-	return HospitalClinicaZF{models.NewRequestWrapper(b.factura)}
+	return HospitalClinicaZF{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type hospitalClinicaZFCabeceraBuilder struct {

--- a/pkg/models/invoices/hotel.go
+++ b/pkg/models/invoices/hotel.go
@@ -18,6 +18,7 @@ import (
 // lista para ser procesada.
 type Hotel struct {
 	models.RequestWrapper[documents.FacturaHotel]
+	models.MetadatosFactura
 }
 
 // HotelCabecera representa la sección de cabecera de la factura.
@@ -33,6 +34,7 @@ type HotelDetalle struct {
 // NewHotel inicia el proceso de construcción de la factura.
 func NewHotelBuilder() *hotelBuilder {
 	return &hotelBuilder{
+		metadatos: models.NuevosMetadatosFactura(16),
 		factura: &documents.FacturaHotel{
 			XMLName:           xml.Name{Local: "facturaElectronicaHotel"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -58,7 +60,14 @@ func NewHotelDetalleBuilder() *hotelDetalleBuilder {
 }
 
 type hotelBuilder struct {
-	factura *documents.FacturaHotel
+	factura   *documents.FacturaHotel
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de hotel.
+func (b *hotelBuilder) WithTipoFacturaDocumento(tipo int) *hotelBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *hotelBuilder) WithCabecera(req HotelCabecera) *hotelBuilder {
@@ -88,7 +97,7 @@ func (b *hotelBuilder) WithModalidad(tipo int) *hotelBuilder {
 }
 
 func (b *hotelBuilder) Build() Hotel {
-	return Hotel{models.NewRequestWrapper(b.factura)}
+	return Hotel{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type hotelCabeceraBuilder struct {

--- a/pkg/models/invoices/importacion_comercializacion_lubricantes.go
+++ b/pkg/models/invoices/importacion_comercializacion_lubricantes.go
@@ -15,6 +15,7 @@ import (
 
 // ImportacionComercializacionLubricantes representa la estructura completa de una factura de Sector 44.
 type ImportacionComercializacionLubricantes struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaImportacionComercializacionLubricantes]
 }
 
@@ -31,6 +32,7 @@ type ImportacionComercializacionLubricantesDetalle struct {
 // NewImportacionComercializacionLubricantesBuilder inicia el proceso de construcción.
 func NewImportacionComercializacionLubricantesBuilder() *importacionComercializacionLubricantesBuilder {
 	return &importacionComercializacionLubricantesBuilder{
+		metadatos: models.NuevosMetadatosFactura(44),
 		factura: &documents.FacturaImportacionComercializacionLubricantes{
 			XMLName:  xml.Name{Local: "facturaElectronicaImportacionComercializacionLubricantes"},
 			XmlnsXsi: "http://www.w3.org/2001/XMLSchema-instance",
@@ -55,7 +57,8 @@ func NewImportacionComercializacionLubricantesDetalleBuilder() *importacionComer
 }
 
 type importacionComercializacionLubricantesBuilder struct {
-	factura *documents.FacturaImportacionComercializacionLubricantes
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaImportacionComercializacionLubricantes
 }
 
 func (b *importacionComercializacionLubricantesBuilder) WithCabecera(req ImportacionComercializacionLubricantesCabecera) *importacionComercializacionLubricantesBuilder {
@@ -83,7 +86,7 @@ func (b *importacionComercializacionLubricantesBuilder) WithModalidad(tipo int) 
 }
 
 func (b *importacionComercializacionLubricantesBuilder) Build() ImportacionComercializacionLubricantes {
-	return ImportacionComercializacionLubricantes{models.NewRequestWrapper(b.factura)}
+	return ImportacionComercializacionLubricantes{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type importacionComercializacionLubricantesCabeceraBuilder struct {

--- a/pkg/models/invoices/juego_azar.go
+++ b/pkg/models/invoices/juego_azar.go
@@ -15,6 +15,7 @@ import (
 
 // JuegoAzar representa la estructura completa de una factura de Juego de Azar lista para ser procesada.
 type JuegoAzar struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaJuegoAzar]
 }
 
@@ -31,6 +32,7 @@ type JuegoAzarDetalle struct {
 // NewJuegoAzarBuilder inicia el proceso de construcción de una Factura de Juego de Azar.
 func NewJuegoAzarBuilder() *juegoAzarBuilder {
 	return &juegoAzarBuilder{
+		metadatos: models.NuevosMetadatosFactura(18),
 		factura: &documents.FacturaJuegoAzar{
 			XMLName:           xml.Name{Local: "facturaElectronicaJuegoAzar"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewJuegoAzarDetalleBuilder() *juegoAzarDetalleBuilder {
 }
 
 type juegoAzarBuilder struct {
-	factura *documents.FacturaJuegoAzar
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaJuegoAzar
 }
 
 func (b *juegoAzarBuilder) WithCabecera(req JuegoAzarCabecera) *juegoAzarBuilder {
@@ -86,7 +89,7 @@ func (b *juegoAzarBuilder) WithModalidad(tipo int) *juegoAzarBuilder {
 }
 
 func (b *juegoAzarBuilder) Build() JuegoAzar {
-	return JuegoAzar{models.NewRequestWrapper(b.factura)}
+	return JuegoAzar{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type juegoAzarCabeceraBuilder struct {

--- a/pkg/models/invoices/libre_consignacion.go
+++ b/pkg/models/invoices/libre_consignacion.go
@@ -15,6 +15,7 @@ import (
 
 // LibreConsignacion representa la estructura completa de una factura Libre Consignación lista para ser procesada.
 type LibreConsignacion struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaLibreConsignacion]
 }
 
@@ -31,6 +32,7 @@ type LibreConsignacionDetalle struct {
 // NewLibreConsignacionBuilder inicia el proceso de construcción de una Factura Libre Consignación.
 func NewLibreConsignacionBuilder() *libreConsignacionBuilder {
 	return &libreConsignacionBuilder{
+		metadatos: models.NuevosMetadatosFactura(4),
 		factura: &documents.FacturaLibreConsignacion{
 			XMLName:           xml.Name{Local: "facturaElectronicaLibreConsignacion"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -62,7 +64,8 @@ func NewLibreConsignacionDetalleBuilder() *libreConsignacionDetalleBuilder {
 }
 
 type libreConsignacionBuilder struct {
-	factura *documents.FacturaLibreConsignacion
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaLibreConsignacion
 }
 
 func (b *libreConsignacionBuilder) WithCabecera(req LibreConsignacionCabecera) *libreConsignacionBuilder {
@@ -92,7 +95,7 @@ func (b *libreConsignacionBuilder) WithModalidad(tipo int) *libreConsignacionBui
 }
 
 func (b *libreConsignacionBuilder) Build() LibreConsignacion {
-	return LibreConsignacion{models.NewRequestWrapper(b.factura)}
+	return LibreConsignacion{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type libreConsignacionCabeceraBuilder struct {

--- a/pkg/models/invoices/lubricantes_iehd.go
+++ b/pkg/models/invoices/lubricantes_iehd.go
@@ -16,6 +16,7 @@ import (
 // LubricantesIehd representa la estructura completa de una factura Sector 53
 // lista para ser procesada.
 type LubricantesIehd struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaLubricantesIehd]
 }
 
@@ -32,6 +33,7 @@ type LubricantesIehdDetalle struct {
 // NewLubricantesIehd inicia el proceso de construcción de la factura.
 func NewLubricantesIehdBuilder() *lubricantesIehdBuilder {
 	return &lubricantesIehdBuilder{
+		metadatos: models.NuevosMetadatosFactura(53),
 		factura: &documents.FacturaLubricantesIehd{
 			XMLName:           xml.Name{Local: "facturaElectronicaImportacionComercializacionLubricantesIEHD"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewLubricantesIehdDetalleBuilder() *lubricantesIehdDetalleBuilder {
 }
 
 type lubricantesIehdBuilder struct {
-	factura *documents.FacturaLubricantesIehd
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaLubricantesIehd
 }
 
 func (b *lubricantesIehdBuilder) WithCabecera(req LubricantesIehdCabecera) *lubricantesIehdBuilder {
@@ -87,7 +90,7 @@ func (b *lubricantesIehdBuilder) WithModalidad(tipo int) *lubricantesIehdBuilder
 }
 
 func (b *lubricantesIehdBuilder) Build() LubricantesIehd {
-	return LubricantesIehd{models.NewRequestWrapper(b.factura)}
+	return LubricantesIehd{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type lubricantesIehdCabeceraBuilder struct {

--- a/pkg/models/invoices/moneda_extranjera.go
+++ b/pkg/models/invoices/moneda_extranjera.go
@@ -15,6 +15,7 @@ import (
 
 // MonedaExtranjera representa la estructura completa de una factura de Sector 9.
 type MonedaExtranjera struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaMonedaExtranjera]
 }
 
@@ -31,6 +32,7 @@ type MonedaExtranjeraDetalle struct {
 // NewMonedaExtranjeraBuilder inicia el proceso de construcción.
 func NewMonedaExtranjeraBuilder() *monedaExtranjeraBuilder {
 	return &monedaExtranjeraBuilder{
+		metadatos: models.NuevosMetadatosFactura(9),
 		factura: &documents.FacturaMonedaExtranjera{
 			XMLName:  xml.Name{Local: "facturaElectronicaMonedaExtranjera"},
 			XmlnsXsi: "http://www.w3.org/2001/XMLSchema-instance",
@@ -55,7 +57,8 @@ func NewMonedaExtranjeraDetalleBuilder() *monedaExtranjeraDetalleBuilder {
 }
 
 type monedaExtranjeraBuilder struct {
-	factura *documents.FacturaMonedaExtranjera
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaMonedaExtranjera
 }
 
 func (b *monedaExtranjeraBuilder) WithCabecera(req MonedaExtranjeraCabecera) *monedaExtranjeraBuilder {
@@ -83,7 +86,7 @@ func (b *monedaExtranjeraBuilder) WithModalidad(tipo int) *monedaExtranjeraBuild
 }
 
 func (b *monedaExtranjeraBuilder) Build() MonedaExtranjera {
-	return MonedaExtranjera{models.NewRequestWrapper(b.factura)}
+	return MonedaExtranjera{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type monedaExtranjeraCabeceraBuilder struct {

--- a/pkg/models/invoices/nota_conciliacion.go
+++ b/pkg/models/invoices/nota_conciliacion.go
@@ -14,6 +14,7 @@ import (
 // NotaConciliacion representa la estructura completa de una nota de conciliación lista para ser procesada.
 type NotaConciliacion struct {
 	models.RequestWrapper[documents.NotaConciliacion]
+	models.MetadatosFactura
 }
 
 // NotaConciliacionCabecera representa la sección de cabecera de una nota de conciliación.
@@ -34,6 +35,7 @@ type NotaDetalleConciliacion struct {
 // NewNotaConciliacionBuilder inicia el proceso de construcción de una Nota de Conciliación.
 func NewNotaConciliacionBuilder() *notaConciliacionBuilder {
 	return &notaConciliacionBuilder{
+		metadatos: models.NuevosMetadatosFactura(29),
 		nota: &documents.NotaConciliacion{
 			XMLName:           xml.Name{Local: "notaElectronicaConciliacion"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -66,7 +68,8 @@ func NewNotaDetalleConciliacionBuilder() *notaDetalleConciliacionBuilder {
 }
 
 type notaConciliacionBuilder struct {
-	nota *documents.NotaConciliacion
+	metadatos models.MetadatosFactura
+	nota      *documents.NotaConciliacion
 }
 
 func (b *notaConciliacionBuilder) WithCabecera(req NotaConciliacionCabecera) *notaConciliacionBuilder {
@@ -104,7 +107,7 @@ func (b *notaConciliacionBuilder) WithModalidad(tipo int) *notaConciliacionBuild
 }
 
 func (b *notaConciliacionBuilder) Build() NotaConciliacion {
-	return NotaConciliacion{models.NewRequestWrapper(b.nota)}
+	return NotaConciliacion{RequestWrapper: models.NewRequestWrapper(b.nota), MetadatosFactura: b.metadatos}
 }
 
 type notaConciliacionCabeceraBuilder struct {

--- a/pkg/models/invoices/nota_credito_debito.go
+++ b/pkg/models/invoices/nota_credito_debito.go
@@ -14,6 +14,7 @@ import (
 // NotaCreditoDebito representa la estructura completa de una nota de crédito/débito/descuento lista para ser procesada.
 type NotaCreditoDebito struct {
 	models.RequestWrapper[documents.NotaCreditoDebito]
+	models.MetadatosFactura
 }
 
 // NotaCreditoDebitoCabecera representa la sección de cabecera de la nota.
@@ -29,6 +30,7 @@ type NotaDetalleCreditoDebito struct {
 // NewNotaCreditoDebitoBuilder inicia el proceso de construcción de una Nota.
 func NewNotaCreditoDebitoBuilder() *notaCreditoDebitoBuilder {
 	return &notaCreditoDebitoBuilder{
+		metadatos: models.NuevosMetadatosFactura(24),
 		nota: &documents.NotaCreditoDebito{
 			XMLName:           xml.Name{Local: "notaFiscalElectronicaCreditoDebito"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -54,7 +56,8 @@ func NewNotaDetalleCreditoDebitoBuilder() *notaDetalleCreditoDebitoBuilder {
 }
 
 type notaCreditoDebitoBuilder struct {
-	nota *documents.NotaCreditoDebito
+	metadatos models.MetadatosFactura
+	nota      *documents.NotaCreditoDebito
 }
 
 func (b *notaCreditoDebitoBuilder) WithCabecera(req NotaCreditoDebitoCabecera) *notaCreditoDebitoBuilder {
@@ -84,7 +87,7 @@ func (b *notaCreditoDebitoBuilder) WithModalidad(tipo int) *notaCreditoDebitoBui
 }
 
 func (b *notaCreditoDebitoBuilder) Build() NotaCreditoDebito {
-	return NotaCreditoDebito{models.NewRequestWrapper(b.nota)}
+	return NotaCreditoDebito{RequestWrapper: models.NewRequestWrapper(b.nota), MetadatosFactura: b.metadatos}
 }
 
 type notaCreditoDebitoCabeceraBuilder struct {

--- a/pkg/models/invoices/nota_credito_debito_descuento.go
+++ b/pkg/models/invoices/nota_credito_debito_descuento.go
@@ -13,6 +13,7 @@ import (
 
 type NotaCreditoDebitoDescuento struct {
 	models.RequestWrapper[documents.NotaCreditoDebitoDescuento]
+	models.MetadatosFactura
 }
 
 type NotaCreditoDebitoDescuentoCabecera struct {
@@ -25,6 +26,7 @@ type NotaDetalleCreditoDebitoDescuento struct {
 
 func NewNotaCreditoDebitoDescuentoBuilder() *notaCreditoDebitoDescuentoBuilder {
 	return &notaCreditoDebitoDescuentoBuilder{
+		metadatos: models.NuevosMetadatosFactura(47),
 		nota: &documents.NotaCreditoDebitoDescuento{
 			XMLName:           xml.Name{Local: "notaElectronicaCreditoDebitoDescuento"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -48,7 +50,8 @@ func NewNotaDetalleCreditoDebitoDescuentoBuilder() *notaDetalleCreditoDebitoDesc
 }
 
 type notaCreditoDebitoDescuentoBuilder struct {
-	nota *documents.NotaCreditoDebitoDescuento
+	metadatos models.MetadatosFactura
+	nota      *documents.NotaCreditoDebitoDescuento
 }
 
 func (b *notaCreditoDebitoDescuentoBuilder) WithCabecera(req NotaCreditoDebitoDescuentoCabecera) *notaCreditoDebitoDescuentoBuilder {
@@ -78,7 +81,7 @@ func (b *notaCreditoDebitoDescuentoBuilder) WithModalidad(tipo int) *notaCredito
 }
 
 func (b *notaCreditoDebitoDescuentoBuilder) Build() NotaCreditoDebitoDescuento {
-	return NotaCreditoDebitoDescuento{models.NewRequestWrapper(b.nota)}
+	return NotaCreditoDebitoDescuento{RequestWrapper: models.NewRequestWrapper(b.nota), MetadatosFactura: b.metadatos}
 }
 
 type notaCreditoDebitoDescuentoCabeceraBuilder struct {

--- a/pkg/models/invoices/nota_credito_debito_ice.go
+++ b/pkg/models/invoices/nota_credito_debito_ice.go
@@ -13,6 +13,7 @@ import (
 // NotaCreditoDebitoIce representa la estructura completa de una nota de crédito/débito/descuento ICE lista para procesarse.
 type NotaCreditoDebitoIce struct {
 	models.RequestWrapper[documents.NotaCreditoDebitoIce]
+	models.MetadatosFactura
 }
 
 // NotaCreditoDebitoIceCabecera representa la sección de cabecera de la nota ICE.
@@ -28,6 +29,7 @@ type NotaDetalleCreditoDebitoIce struct {
 // NewNotaCreditoDebitoIceBuilder inicia el proceso de construcción de una Nota ICE.
 func NewNotaCreditoDebitoIceBuilder() *notaCreditoDebitoIceBuilder {
 	return &notaCreditoDebitoIceBuilder{
+		metadatos: models.NuevosMetadatosFactura(48),
 		nota: &documents.NotaCreditoDebitoIce{
 			XMLName:           xml.Name{Local: "notaElectronicaCreditoDebitoIce"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -53,7 +55,8 @@ func NewNotaDetalleCreditoDebitoIceBuilder() *notaDetalleCreditoDebitoIceBuilder
 }
 
 type notaCreditoDebitoIceBuilder struct {
-	nota *documents.NotaCreditoDebitoIce
+	metadatos models.MetadatosFactura
+	nota      *documents.NotaCreditoDebitoIce
 }
 
 func (b *notaCreditoDebitoIceBuilder) WithCabecera(req NotaCreditoDebitoIceCabecera) *notaCreditoDebitoIceBuilder {
@@ -83,7 +86,7 @@ func (b *notaCreditoDebitoIceBuilder) WithModalidad(tipo int) *notaCreditoDebito
 }
 
 func (b *notaCreditoDebitoIceBuilder) Build() NotaCreditoDebitoIce {
-	return NotaCreditoDebitoIce{models.NewRequestWrapper(b.nota)}
+	return NotaCreditoDebitoIce{RequestWrapper: models.NewRequestWrapper(b.nota), MetadatosFactura: b.metadatos}
 }
 
 type notaCreditoDebitoIceCabeceraBuilder struct {

--- a/pkg/models/invoices/nota_fiscal_credito_debito.go
+++ b/pkg/models/invoices/nota_fiscal_credito_debito.go
@@ -14,6 +14,7 @@ import (
 // NotaFiscalCreditoDebito representa la estructura completa de una nota de crédito/débito standard (Sector 24) lista para ser procesada.
 type NotaFiscalCreditoDebito struct {
 	models.RequestWrapper[documents.NotaFiscalCreditoDebito]
+	models.MetadatosFactura
 }
 
 // NotaFiscalCreditoDebitoCabecera representa la sección de cabecera de la nota (Sector 24).
@@ -29,6 +30,7 @@ type NotaDetalleFiscalCreditoDebito struct {
 // NewNotaFiscalCreditoDebitoBuilder inicia el proceso de construcción de una Nota Fiscal.
 func NewNotaFiscalCreditoDebitoBuilder() *notaFiscalCreditoDebitoBuilder {
 	return &notaFiscalCreditoDebitoBuilder{
+		metadatos: models.NuevosMetadatosFactura(24),
 		nota: &documents.NotaFiscalCreditoDebito{
 			XMLName:           xml.Name{Local: "notaFiscalElectronicaCreditoDebito"}, // Default a electrónica
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -54,7 +56,8 @@ func NewNotaDetalleFiscalCreditoDebitoBuilder() *notaDetalleFiscalCreditoDebitoB
 }
 
 type notaFiscalCreditoDebitoBuilder struct {
-	nota *documents.NotaFiscalCreditoDebito
+	metadatos models.MetadatosFactura
+	nota      *documents.NotaFiscalCreditoDebito
 }
 
 func (b *notaFiscalCreditoDebitoBuilder) WithCabecera(req NotaFiscalCreditoDebitoCabecera) *notaFiscalCreditoDebitoBuilder {
@@ -84,7 +87,7 @@ func (b *notaFiscalCreditoDebitoBuilder) WithModalidad(tipo int) *notaFiscalCred
 }
 
 func (b *notaFiscalCreditoDebitoBuilder) Build() NotaFiscalCreditoDebito {
-	return NotaFiscalCreditoDebito{models.NewRequestWrapper(b.nota)}
+	return NotaFiscalCreditoDebito{RequestWrapper: models.NewRequestWrapper(b.nota), MetadatosFactura: b.metadatos}
 }
 
 type notaFiscalCreditoDebitoCabeceraBuilder struct {

--- a/pkg/models/invoices/prevalorada.go
+++ b/pkg/models/invoices/prevalorada.go
@@ -15,6 +15,7 @@ import (
 
 // Prevalorada representa la estructura completa de una factura Prevalorada lista para ser procesada.
 type Prevalorada struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaPrevalorada]
 }
 
@@ -31,6 +32,7 @@ type PrevaloradaDetalle struct {
 // NewPrevaloradaBuilder inicia el proceso de construcción de una Factura Prevalorada.
 func NewPrevaloradaBuilder() *prevaloradaBuilder {
 	return &prevaloradaBuilder{
+		metadatos: models.NuevosMetadatosFactura(23),
 		factura: &documents.FacturaPrevalorada{
 			XMLName:           xml.Name{Local: "facturaElectronicaPrevalorada"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -60,7 +62,8 @@ func NewPrevaloradaDetalleBuilder() *prevaloradaDetalleBuilder {
 }
 
 type prevaloradaBuilder struct {
-	factura *documents.FacturaPrevalorada
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaPrevalorada
 }
 
 func (b *prevaloradaBuilder) WithCabecera(req PrevaloradaCabecera) *prevaloradaBuilder {
@@ -90,7 +93,7 @@ func (b *prevaloradaBuilder) WithModalidad(tipo int) *prevaloradaBuilder {
 }
 
 func (b *prevaloradaBuilder) Build() Prevalorada {
-	return Prevalorada{models.NewRequestWrapper(b.factura)}
+	return Prevalorada{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type prevaloradaCabeceraBuilder struct {

--- a/pkg/models/invoices/prevalorada_sin_derecho_credito_fiscal.go
+++ b/pkg/models/invoices/prevalorada_sin_derecho_credito_fiscal.go
@@ -14,6 +14,7 @@ import (
 )
 
 type FacturaPrevaloradaSinDerechoCreditoFiscal struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaPrevaloradaSinDerechoCreditoFiscal]
 }
 
@@ -27,6 +28,7 @@ type FacturaPrevaloradaSinDerechoCreditoFiscalDetalle struct {
 
 func NewPrevaloradaSinDerechoCreditoFiscalBuilder() *prevaloradaSinDerechoCreditoFiscalBuilder {
 	return &prevaloradaSinDerechoCreditoFiscalBuilder{
+		metadatos: models.NuevosMetadatosFactura(36),
 		factura: &documents.FacturaPrevaloradaSinDerechoCreditoFiscal{
 			XMLName:           xml.Name{Local: "facturaElectronicaPrevaloradaSD"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -36,7 +38,8 @@ func NewPrevaloradaSinDerechoCreditoFiscalBuilder() *prevaloradaSinDerechoCredit
 }
 
 type prevaloradaSinDerechoCreditoFiscalBuilder struct {
-	factura *documents.FacturaPrevaloradaSinDerechoCreditoFiscal
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaPrevaloradaSinDerechoCreditoFiscal
 }
 
 func (b *prevaloradaSinDerechoCreditoFiscalBuilder) WithCabecera(req FacturaPrevaloradaSinDerechoCreditoFiscalCabecera) *prevaloradaSinDerechoCreditoFiscalBuilder {
@@ -66,7 +69,7 @@ func (b *prevaloradaSinDerechoCreditoFiscalBuilder) WithDetalle(req FacturaPreva
 }
 
 func (b *prevaloradaSinDerechoCreditoFiscalBuilder) Build() FacturaPrevaloradaSinDerechoCreditoFiscal {
-	return FacturaPrevaloradaSinDerechoCreditoFiscal{models.NewRequestWrapper(b.factura)}
+	return FacturaPrevaloradaSinDerechoCreditoFiscal{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type prevaloradaSinDerechoCreditoFiscalCabeceraBuilder struct {

--- a/pkg/models/invoices/sector_educativo.go
+++ b/pkg/models/invoices/sector_educativo.go
@@ -16,6 +16,7 @@ import (
 // SectorEducativo representa la estructura completa de una factura del Sector Educativo lista para ser procesada.
 type SectorEducativo struct {
 	models.RequestWrapper[documents.FacturaSectorEducativo]
+	models.MetadatosFactura
 }
 
 // SectorEducativoCabecera representa la sección de cabecera de una factura del Sector Educativo.
@@ -31,6 +32,7 @@ type SectorEducativoDetalle struct {
 // NewSectorEducativoBuilder inicia el proceso de construcción de una Factura del Sector Educativo.
 func NewSectorEducativoBuilder() *sectorEducativoBuilder {
 	return &sectorEducativoBuilder{
+		metadatos: models.NuevosMetadatosFactura(11),
 		factura: &documents.FacturaSectorEducativo{
 			XMLName:           xml.Name{Local: "facturaElectronicaSectorEducativo"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,14 @@ func NewSectorEducativoDetalleBuilder() *sectorEducativoDetalleBuilder {
 }
 
 type sectorEducativoBuilder struct {
-	factura *documents.FacturaSectorEducativo
+	factura   *documents.FacturaSectorEducativo
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado del sector educativo.
+func (b *sectorEducativoBuilder) WithTipoFacturaDocumento(tipo int) *sectorEducativoBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *sectorEducativoBuilder) WithCabecera(req SectorEducativoCabecera) *sectorEducativoBuilder {
@@ -86,7 +95,7 @@ func (b *sectorEducativoBuilder) WithModalidad(tipo int) *sectorEducativoBuilder
 }
 
 func (b *sectorEducativoBuilder) Build() SectorEducativo {
-	return SectorEducativo{models.NewRequestWrapper(b.factura)}
+	return SectorEducativo{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type sectorEducativoCabeceraBuilder struct {

--- a/pkg/models/invoices/sector_educativo_zona_franca.go
+++ b/pkg/models/invoices/sector_educativo_zona_franca.go
@@ -15,6 +15,7 @@ import (
 
 // SectorEducativoZF representa la estructura completa de una factura del Sector Educativo ZF lista para ser procesada.
 type SectorEducativoZF struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaSectorEducativoZF]
 }
 
@@ -31,6 +32,7 @@ type SectorEducativoZFDetalle struct {
 // NewSectorEducativoZFBuilder inicia el proceso de construcción de una Factura del Sector Educativo ZonaFranca.
 func NewSectorEducativoZFBuilder() *sectorEducativoZFBuilder {
 	return &sectorEducativoZFBuilder{
+		metadatos: models.NuevosMetadatosFactura(46),
 		factura: &documents.FacturaSectorEducativoZF{
 			XMLName:           xml.Name{Local: "facturaElectronicaSectorEducativoZF"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewSectorEducativoZFDetalleBuilder() *sectorEducativoZFDetalleBuilder {
 }
 
 type sectorEducativoZFBuilder struct {
-	factura *documents.FacturaSectorEducativoZF
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaSectorEducativoZF
 }
 
 func (b *sectorEducativoZFBuilder) WithCabecera(req SectorEducativoZFCabecera) *sectorEducativoZFBuilder {
@@ -86,7 +89,7 @@ func (b *sectorEducativoZFBuilder) WithModalidad(tipo int) *sectorEducativoZFBui
 }
 
 func (b *sectorEducativoZFBuilder) Build() SectorEducativoZF {
-	return SectorEducativoZF{models.NewRequestWrapper(b.factura)}
+	return SectorEducativoZF{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type sectorEducativoZFCabeceraBuilder struct {

--- a/pkg/models/invoices/sectores_catalogo_test.go
+++ b/pkg/models/invoices/sectores_catalogo_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	siat "github.com/ron86i/go-siat/v2"
+	"github.com/ron86i/go-siat/v2/pkg/models"
 	"github.com/ron86i/go-siat/v2/pkg/models/invoices"
 )
 
@@ -208,5 +209,46 @@ func TestSectores_CoberturaCatalogo(t *testing.T) {
 
 	if cubiertos[33] {
 		t.Error("el sector 33 no tiene builder en el SDK; si se agregó, actualizá la documentación")
+	}
+}
+
+func TestSectores_TipoFacturaDocumentoPredeterminado(t *testing.T) {
+	catalogo := invoices.DefinicionesTipoFactura()
+	definiciones := make(map[int]int, len(catalogo))
+	for _, definicion := range catalogo {
+		if _, duplicado := definiciones[definicion.CodigoDocumentoSector]; duplicado {
+			t.Fatalf("el sector %d está duplicado en DefinicionesTipoFactura", definicion.CodigoDocumentoSector)
+		}
+		definiciones[definicion.CodigoDocumentoSector] = definicion.TipoFacturaDocumento
+	}
+	for _, c := range sectorCases() {
+		t.Run(c.nombre, func(t *testing.T) {
+			documento, ok := c.build(siat.ModalidadElectronica).(models.FacturaConMetadatos)
+			if !ok {
+				t.Fatal("la factura no expone sus metadatos fiscales")
+			}
+			if obtenido := documento.CodigoDocumentoSector(); obtenido != c.codigo {
+				t.Fatalf("sector del metadato = %d; se esperaba %d", obtenido, c.codigo)
+			}
+			esperado, existe := definiciones[c.codigo]
+			if !existe {
+				t.Fatalf("el sector %d no está definido en DefinicionesTipoFactura", c.codigo)
+			}
+			if obtenido := documento.TipoFacturaDocumento(); obtenido != esperado {
+				t.Fatalf("tipo de factura = %d; se esperaba %d", obtenido, esperado)
+			}
+		})
+	}
+	if len(definiciones) != len(sectorCases())-1 {
+		t.Fatalf("definiciones = %d; se esperaban %d sectores únicos", len(definiciones), len(sectorCases())-1)
+	}
+}
+
+func TestSectores_CatalogoTiposFacturaEsInmutable(t *testing.T) {
+	catalogo := invoices.DefinicionesTipoFactura()
+	original := catalogo[0].TipoFacturaDocumento
+	catalogo[0].TipoFacturaDocumento = 999
+	if obtenido := invoices.DefinicionesTipoFactura()[0].TipoFacturaDocumento; obtenido != original {
+		t.Fatalf("el catálogo público fue modificado: %d", obtenido)
 	}
 }

--- a/pkg/models/invoices/seguridad_alimentaria.go
+++ b/pkg/models/invoices/seguridad_alimentaria.go
@@ -15,6 +15,7 @@ import (
 
 // SeguridadAlimentaria representa la estructura completa de una factura de Seguridad Alimentaria lista para ser procesada.
 type SeguridadAlimentaria struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaSeguridadAlimentaria]
 }
 
@@ -31,6 +32,7 @@ type SeguridadAlimentariaDetalle struct {
 // NewSeguridadAlimentariaBuilder inicia el proceso de construcción de la factura.
 func NewSeguridadAlimentariaBuilder() *seguridadAlimentariaBuilder {
 	return &seguridadAlimentariaBuilder{
+		metadatos: models.NuevosMetadatosFactura(7),
 		factura: &documents.FacturaSeguridadAlimentaria{
 			XMLName:           xml.Name{Local: "facturaElectronicaSeguridadAlimentaria"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewSeguridadAlimentariaDetalleBuilder() *seguridadAlimentariaDetalleBuilder
 }
 
 type seguridadAlimentariaBuilder struct {
-	factura *documents.FacturaSeguridadAlimentaria
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaSeguridadAlimentaria
 }
 
 func (b *seguridadAlimentariaBuilder) WithCabecera(req SeguridadAlimentariaCabecera) *seguridadAlimentariaBuilder {
@@ -88,7 +91,7 @@ func (b *seguridadAlimentariaBuilder) WithModalidad(tipo int) *seguridadAlimenta
 }
 
 func (b *seguridadAlimentariaBuilder) Build() SeguridadAlimentaria {
-	return SeguridadAlimentaria{models.NewRequestWrapper(b.factura)}
+	return SeguridadAlimentaria{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type seguridadAlimentariaCabeceraBuilder struct {

--- a/pkg/models/invoices/seguros.go
+++ b/pkg/models/invoices/seguros.go
@@ -15,6 +15,7 @@ import (
 
 // Seguros representa la estructura completa de una factura de Seguros lista para ser procesada.
 type Seguros struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaSeguros]
 }
 
@@ -31,6 +32,7 @@ type SegurosDetalle struct {
 // NewSegurosBuilder inicia el proceso de construcción de una Factura de Seguros.
 func NewSegurosBuilder() *segurosBuilder {
 	return &segurosBuilder{
+		metadatos: models.NuevosMetadatosFactura(34),
 		factura: &documents.FacturaSeguros{
 			XMLName:           xml.Name{Local: "facturaElectronicaSeguros"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewSegurosDetalleBuilder() *segurosDetalleBuilder {
 }
 
 type segurosBuilder struct {
-	factura *documents.FacturaSeguros
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaSeguros
 }
 
 func (b *segurosBuilder) WithCabecera(req SegurosCabecera) *segurosBuilder {
@@ -86,7 +89,7 @@ func (b *segurosBuilder) WithModalidad(tipo int) *segurosBuilder {
 }
 
 func (b *segurosBuilder) Build() Seguros {
-	return Seguros{models.NewRequestWrapper(b.factura)}
+	return Seguros{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type segurosCabeceraBuilder struct {

--- a/pkg/models/invoices/servicio_basico.go
+++ b/pkg/models/invoices/servicio_basico.go
@@ -13,6 +13,7 @@ import (
 
 // ServicioBasico representa la estructura completa de una factura de servicio básico lista para ser procesada.
 type ServicioBasico struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaServicioBasico]
 }
 
@@ -27,11 +28,13 @@ type ServicioBasicoDetalle struct {
 }
 
 type servicioBasicoBuilder struct {
-	factura *documents.FacturaServicioBasico
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaServicioBasico
 }
 
 func NewServicioBasicoBuilder() *servicioBasicoBuilder {
 	return &servicioBasicoBuilder{
+		metadatos: models.NuevosMetadatosFactura(13),
 		factura: &documents.FacturaServicioBasico{
 			XMLName:           xml.Name{Local: "facturaElectronicaServicioBasico"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -67,7 +70,7 @@ func (b *servicioBasicoBuilder) AddDetalle(req ServicioBasicoDetalle) *servicioB
 }
 
 func (b *servicioBasicoBuilder) Build() ServicioBasico {
-	return ServicioBasico{models.NewRequestWrapper(b.factura)}
+	return ServicioBasico{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // Cabecera Builder

--- a/pkg/models/invoices/servicio_basico_zf.go
+++ b/pkg/models/invoices/servicio_basico_zf.go
@@ -13,6 +13,7 @@ import (
 
 // ServicioBasicoZF representa la estructura completa de una factura de servicio básico ZF lista para ser procesada.
 type ServicioBasicoZF struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaServicioBasicoZF]
 }
 
@@ -27,11 +28,13 @@ type ServicioBasicoZFDetalle struct {
 }
 
 type servicioBasicoZFBuilder struct {
-	factura *documents.FacturaServicioBasicoZF
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaServicioBasicoZF
 }
 
 func NewServicioBasicoZFBuilder() *servicioBasicoZFBuilder {
 	return &servicioBasicoZFBuilder{
+		metadatos: models.NuevosMetadatosFactura(40),
 		factura: &documents.FacturaServicioBasicoZF{
 			XMLName:           xml.Name{Local: "facturaElectronicaServicioBasicoZf"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -67,7 +70,7 @@ func (b *servicioBasicoZFBuilder) AddDetalle(req ServicioBasicoZFDetalle) *servi
 }
 
 func (b *servicioBasicoZFBuilder) Build() ServicioBasicoZF {
-	return ServicioBasicoZF{models.NewRequestWrapper(b.factura)}
+	return ServicioBasicoZF{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // Cabecera Builder

--- a/pkg/models/invoices/suministro_energia.go
+++ b/pkg/models/invoices/suministro_energia.go
@@ -15,6 +15,7 @@ import (
 
 // SuministroEnergia representa la estructura completa de una factura de Suministro de Energía lista para ser procesada.
 type SuministroEnergia struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaSuministroEnergia]
 }
 
@@ -31,6 +32,7 @@ type SuministroEnergiaDetalle struct {
 // NewSuministroEnergiaBuilder inicia el proceso de construcción de una Factura de Suministro de Energía.
 func NewSuministroEnergiaBuilder() *suministroEnergiaBuilder {
 	return &suministroEnergiaBuilder{
+		metadatos: models.NuevosMetadatosFactura(31),
 		factura: &documents.FacturaSuministroEnergia{
 			XMLName:           xml.Name{Local: "facturaElectronicaSuministroEnergia"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewSuministroEnergiaDetalleBuilder() *suministroEnergiaDetalleBuilder {
 }
 
 type suministroEnergiaBuilder struct {
-	factura *documents.FacturaSuministroEnergia
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaSuministroEnergia
 }
 
 func (b *suministroEnergiaBuilder) WithCabecera(req SuministroEnergiaCabecera) *suministroEnergiaBuilder {
@@ -86,7 +89,7 @@ func (b *suministroEnergiaBuilder) WithModalidad(tipo int) *suministroEnergiaBui
 }
 
 func (b *suministroEnergiaBuilder) Build() SuministroEnergia {
-	return SuministroEnergia{models.NewRequestWrapper(b.factura)}
+	return SuministroEnergia{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type suministroEnergiaCabeceraBuilder struct {

--- a/pkg/models/invoices/tasa_cero.go
+++ b/pkg/models/invoices/tasa_cero.go
@@ -16,6 +16,7 @@ import (
 // TasaCero representa la estructura completa de una factura Tasa Cero lista para ser procesada.
 type TasaCero struct {
 	models.RequestWrapper[documents.FacturaTasaCero]
+	models.MetadatosFactura
 }
 
 // TasaCeroCabecera representa la sección de cabecera de una factura Tasa Cero.
@@ -31,6 +32,7 @@ type TasaCeroDetalle struct {
 // NewTasaCeroBuilder inicia el proceso de construcción de una Factura Tasa Cero.
 func NewTasaCeroBuilder() *tasaCeroBuilder {
 	return &tasaCeroBuilder{
+		metadatos: models.NuevosMetadatosFactura(8),
 		factura: &documents.FacturaTasaCero{
 			XMLName:           xml.Name{Local: "facturaElectronicaTasaCero"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,14 @@ func NewTasaCeroDetalleBuilder() *tasaCeroDetalleBuilder {
 }
 
 type tasaCeroBuilder struct {
-	factura *documents.FacturaTasaCero
+	factura   *documents.FacturaTasaCero
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de tasa cero.
+func (b *tasaCeroBuilder) WithTipoFacturaDocumento(tipo int) *tasaCeroBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *tasaCeroBuilder) WithCabecera(req TasaCeroCabecera) *tasaCeroBuilder {
@@ -87,7 +96,7 @@ func (b *tasaCeroBuilder) WithModalidad(tipo int) *tasaCeroBuilder {
 }
 
 func (b *tasaCeroBuilder) Build() TasaCero {
-	return TasaCero{models.NewRequestWrapper(b.factura)}
+	return TasaCero{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type tasaCeroCabeceraBuilder struct {

--- a/pkg/models/invoices/telecomunicaciones.go
+++ b/pkg/models/invoices/telecomunicaciones.go
@@ -13,6 +13,7 @@ import (
 
 // Telecomunicaciones representa la estructura completa de una factura de telecomunicaciones lista para ser procesada.
 type Telecomunicaciones struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaTelecomunicaciones]
 }
 
@@ -31,6 +32,7 @@ type TelecomunicacionesDetalle struct {
 // Por defecto, la factura se configura para ser emitida electrónica.
 func NewTelecomunicacionesBuilder() *telecomunicacionesBuilder {
 	return &telecomunicacionesBuilder{
+		metadatos: models.NuevosMetadatosFactura(22),
 		factura: &documents.FacturaTelecomunicaciones{
 			XMLName:           xml.Name{Local: "facturaElectronicaTelecomunicacion"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -58,7 +60,8 @@ func NewTelecomunicacionesDetalleBuilder() *telecomunicacionesDetalleBuilder {
 }
 
 type telecomunicacionesBuilder struct {
-	factura *documents.FacturaTelecomunicaciones
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaTelecomunicaciones
 }
 
 // WithCabecera asocia la cabecera construida previamente a la factura.
@@ -92,7 +95,7 @@ func (b *telecomunicacionesBuilder) WithModalidad(tipo int) *telecomunicacionesB
 
 // Build finaliza la construcción y retorna la estructura opaca lista para ser firmada y enviada.
 func (b *telecomunicacionesBuilder) Build() Telecomunicaciones {
-	return Telecomunicaciones{models.NewRequestWrapper(b.factura)}
+	return Telecomunicaciones{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // telecomunicacionesCabeceraBuilder ayuda a configurar la cabecera de la factura.

--- a/pkg/models/invoices/telecomunicaciones_zf.go
+++ b/pkg/models/invoices/telecomunicaciones_zf.go
@@ -13,6 +13,7 @@ import (
 
 // TelecomunicacionesZF representa la estructura completa de una factura de telecomunicaciones en Zona Franca.
 type TelecomunicacionesZF struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaTelecomunicacionesZF]
 }
 
@@ -29,6 +30,7 @@ type TelecomunicacionesZFDetalle struct {
 // NewTelecomunicacionesZFBuilder inicia el proceso de construcción de una factura de Telecomunicaciones ZF.
 func NewTelecomunicacionesZFBuilder() *telecomunicacionesZFBuilder {
 	return &telecomunicacionesZFBuilder{
+		metadatos: models.NuevosMetadatosFactura(49),
 		factura: &documents.FacturaTelecomunicacionesZF{
 			XMLName:           xml.Name{Local: "facturaElectronicaTelecomunicacionZF"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -55,7 +57,8 @@ func NewTelecomunicacionesZFDetalleBuilder() *telecomunicacionesZFDetalleBuilder
 }
 
 type telecomunicacionesZFBuilder struct {
-	factura *documents.FacturaTelecomunicacionesZF
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaTelecomunicacionesZF
 }
 
 // WithCabecera asocia la cabecera construida previamente a la factura.
@@ -90,7 +93,7 @@ func (b *telecomunicacionesZFBuilder) WithModalidad(tipo int) *telecomunicacione
 
 // Build finaliza la construcción y retorna la estructura opaca.
 func (b *telecomunicacionesZFBuilder) Build() TelecomunicacionesZF {
-	return TelecomunicacionesZF{models.NewRequestWrapper(b.factura)}
+	return TelecomunicacionesZF{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 // telecomunicacionesZFCabeceraBuilder ayuda a configurar la cabecera de la factura ZF.

--- a/pkg/models/invoices/tipo_factura_documento.go
+++ b/pkg/models/invoices/tipo_factura_documento.go
@@ -1,0 +1,221 @@
+package invoices
+
+import "github.com/ron86i/go-siat/v2/pkg/models"
+
+// DefinicionTipoFactura se mantiene como alias para compatibilidad con los
+// consumidores del paquete invoices. El catálogo vive en models, junto a los
+// metadatos que lo consumen.
+type DefinicionTipoFactura = models.DefinicionTipoFactura
+
+// DefinicionesTipoFactura devuelve el catálogo fiscal compartido.
+func DefinicionesTipoFactura() []DefinicionTipoFactura {
+	return models.DefinicionesTipoFactura()
+}
+
+// Los builders mantienen los metadatos en la factura construida. Estas
+// funciones permiten sobrescribir el tipo fiscal cuando una operación lo
+// requiere, sin ocultar los métodos promovidos de MetadatosFactura.
+func (b *libreConsignacionBuilder) WithTipoFacturaDocumento(tipo int) *libreConsignacionBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *zonaFrancaBuilder) WithTipoFacturaDocumento(tipo int) *zonaFrancaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *seguridadAlimentariaBuilder) WithTipoFacturaDocumento(tipo int) *seguridadAlimentariaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *monedaExtranjeraBuilder) WithTipoFacturaDocumento(tipo int) *monedaExtranjeraBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *duttyFreeBuilder) WithTipoFacturaDocumento(tipo int) *duttyFreeBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercializacionHidroBuilder) WithTipoFacturaDocumento(tipo int) *comercializacionHidroBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *servicioBasicoBuilder) WithTipoFacturaDocumento(tipo int) *servicioBasicoBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *alcanzadaIceBuilder) WithTipoFacturaDocumento(tipo int) *alcanzadaIceBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *entidadFinancieraBuilder) WithTipoFacturaDocumento(tipo int) *entidadFinancieraBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *juegoAzarBuilder) WithTipoFacturaDocumento(tipo int) *juegoAzarBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *hidrocarburoAlcanzadaIehdBuilder) WithTipoFacturaDocumento(tipo int) *hidrocarburoAlcanzadaIehdBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercialExportacionMineraBuilder) WithTipoFacturaDocumento(tipo int) *comercialExportacionMineraBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *ventaMineralBuilder) WithTipoFacturaDocumento(tipo int) *ventaMineralBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *telecomunicacionesBuilder) WithTipoFacturaDocumento(tipo int) *telecomunicacionesBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *prevaloradaBuilder) WithTipoFacturaDocumento(tipo int) *prevaloradaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *notaCreditoDebitoBuilder) WithTipoFacturaDocumento(tipo int) *notaCreditoDebitoBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *notaFiscalCreditoDebitoBuilder) WithTipoFacturaDocumento(tipo int) *notaFiscalCreditoDebitoBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercialExportacionServicioBuilder) WithTipoFacturaDocumento(tipo int) *comercialExportacionServicioBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *notaConciliacionBuilder) WithTipoFacturaDocumento(tipo int) *notaConciliacionBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *boletoAereoBuilder) WithTipoFacturaDocumento(tipo int) *boletoAereoBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *suministroEnergiaBuilder) WithTipoFacturaDocumento(tipo int) *suministroEnergiaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *segurosBuilder) WithTipoFacturaDocumento(tipo int) *segurosBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *prevaloradaSinDerechoCreditoFiscalBuilder) WithTipoFacturaDocumento(tipo int) *prevaloradaSinDerechoCreditoFiscalBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercializacionGnvBuilder) WithTipoFacturaDocumento(tipo int) *comercializacionGnvBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *hidrocarburoNoAlcanzadaIehdBuilder) WithTipoFacturaDocumento(tipo int) *hidrocarburoNoAlcanzadaIehdBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercializacionGnGlpBuilder) WithTipoFacturaDocumento(tipo int) *comercializacionGnGlpBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *servicioBasicoZFBuilder) WithTipoFacturaDocumento(tipo int) *servicioBasicoZFBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *alquilerZFBuilder) WithTipoFacturaDocumento(tipo int) *alquilerZFBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercialExportacionHidroBuilder) WithTipoFacturaDocumento(tipo int) *comercialExportacionHidroBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *importacionComercializacionLubricantesBuilder) WithTipoFacturaDocumento(tipo int) *importacionComercializacionLubricantesBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *comercialExportacionPVentaBuilder) WithTipoFacturaDocumento(tipo int) *comercialExportacionPVentaBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *sectorEducativoZFBuilder) WithTipoFacturaDocumento(tipo int) *sectorEducativoZFBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *notaCreditoDebitoDescuentoBuilder) WithTipoFacturaDocumento(tipo int) *notaCreditoDebitoDescuentoBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *notaCreditoDebitoIceBuilder) WithTipoFacturaDocumento(tipo int) *notaCreditoDebitoIceBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *telecomunicacionesZFBuilder) WithTipoFacturaDocumento(tipo int) *telecomunicacionesZFBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *hospitalClinicaZFBuilder) WithTipoFacturaDocumento(tipo int) *hospitalClinicaZFBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *engarrafadorasBuilder) WithTipoFacturaDocumento(tipo int) *engarrafadorasBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *ventaMineralBCBBuilder) WithTipoFacturaDocumento(tipo int) *ventaMineralBCBBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *lubricantesIehdBuilder) WithTipoFacturaDocumento(tipo int) *lubricantesIehdBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *biodieselBuilder) WithTipoFacturaDocumento(tipo int) *biodieselBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}
+
+func (b *ventaCombustibleSinSubvencionBuilder) WithTipoFacturaDocumento(tipo int) *ventaCombustibleSinSubvencionBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
+}

--- a/pkg/models/invoices/turismo_hospedaje.go
+++ b/pkg/models/invoices/turismo_hospedaje.go
@@ -16,6 +16,7 @@ import (
 // TurismoHospedaje representa la estructura completa de una factura de Turismo y Hospedaje lista para ser procesada.
 type TurismoHospedaje struct {
 	models.RequestWrapper[documents.FacturaTurismoHospedaje]
+	models.MetadatosFactura
 }
 
 // TurismoHospedajeCabecera representa la sección de cabecera de una factura de Turismo y Hospedaje.
@@ -31,6 +32,7 @@ type TurismoHospedajeDetalle struct {
 // NewTurismoHospedajeBuilder inicia el proceso de construcción de una Factura de Turismo y Hospedaje.
 func NewTurismoHospedajeBuilder() *turismoHospedajeBuilder {
 	return &turismoHospedajeBuilder{
+		metadatos: models.NuevosMetadatosFactura(6),
 		factura: &documents.FacturaTurismoHospedaje{
 			XMLName:           xml.Name{Local: "facturaElectronicaServicioTuristicoHospedaje"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,14 @@ func NewTurismoHospedajeDetalleBuilder() *turismoHospedajeDetalleBuilder {
 }
 
 type turismoHospedajeBuilder struct {
-	factura *documents.FacturaTurismoHospedaje
+	factura   *documents.FacturaTurismoHospedaje
+	metadatos models.MetadatosFactura
+}
+
+// WithTipoFacturaDocumento reemplaza el tipo fiscal predeterminado de turismo y hospedaje.
+func (b *turismoHospedajeBuilder) WithTipoFacturaDocumento(tipo int) *turismoHospedajeBuilder {
+	b.metadatos.WithTipoFacturaDocumento(tipo)
+	return b
 }
 
 func (b *turismoHospedajeBuilder) WithCabecera(req TurismoHospedajeCabecera) *turismoHospedajeBuilder {
@@ -87,7 +96,7 @@ func (b *turismoHospedajeBuilder) WithModalidad(tipo int) *turismoHospedajeBuild
 }
 
 func (b *turismoHospedajeBuilder) Build() TurismoHospedaje {
-	return TurismoHospedaje{models.NewRequestWrapper(b.factura)}
+	return TurismoHospedaje{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type turismoHospedajeCabeceraBuilder struct {

--- a/pkg/models/invoices/venta_combustible_sin_subvencion.go
+++ b/pkg/models/invoices/venta_combustible_sin_subvencion.go
@@ -15,6 +15,7 @@ import (
 
 // VentaCombustibleSinSubvencion representa la estructura completa de una factura de Venta de Combustible Sin Subvención lista para ser procesada.
 type VentaCombustibleSinSubvencion struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaVentaCombustibleSinSubvencion]
 }
 
@@ -31,6 +32,7 @@ type VentaCombustibleSinSubvencionDetalle struct {
 // NewVentaCombustibleSinSubvencionBuilder inicia el proceso de construcción de una Factura de Venta de Combustible Sin Subvención.
 func NewVentaCombustibleSinSubvencionBuilder() *ventaCombustibleSinSubvencionBuilder {
 	return &ventaCombustibleSinSubvencionBuilder{
+		metadatos: models.NuevosMetadatosFactura(55),
 		factura: &documents.FacturaVentaCombustibleSinSubvencion{
 			XMLName:           xml.Name{Local: "facturaElectronicaVentaCombustibleSinSubvencion"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -56,7 +58,8 @@ func NewVentaCombustibleSinSubvencionDetalleBuilder() *ventaCombustibleSinSubven
 }
 
 type ventaCombustibleSinSubvencionBuilder struct {
-	factura *documents.FacturaVentaCombustibleSinSubvencion
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaVentaCombustibleSinSubvencion
 }
 
 func (b *ventaCombustibleSinSubvencionBuilder) WithCabecera(req VentaCombustibleSinSubvencionCabecera) *ventaCombustibleSinSubvencionBuilder {
@@ -86,7 +89,7 @@ func (b *ventaCombustibleSinSubvencionBuilder) WithModalidad(tipo int) *ventaCom
 }
 
 func (b *ventaCombustibleSinSubvencionBuilder) Build() VentaCombustibleSinSubvencion {
-	return VentaCombustibleSinSubvencion{models.NewRequestWrapper(b.factura)}
+	return VentaCombustibleSinSubvencion{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type ventaCombustibleSinSubvencionCabeceraBuilder struct {

--- a/pkg/models/invoices/venta_mineral.go
+++ b/pkg/models/invoices/venta_mineral.go
@@ -15,6 +15,7 @@ import (
 
 // VentaMineral representa la estructura completa de una factura de Venta de Minerales lista para ser procesada.
 type VentaMineral struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaVentaMineral]
 }
 
@@ -31,6 +32,7 @@ type VentaMineralDetalle struct {
 // NewVentaMineralBuilder inicia el proceso de construcción de la factura.
 func NewVentaMineralBuilder() *ventaMineralBuilder {
 	return &ventaMineralBuilder{
+		metadatos: models.NuevosMetadatosFactura(21),
 		factura: &documents.FacturaVentaMineral{
 			XMLName:           xml.Name{Local: "facturaElectronicaVentaMineral"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -58,7 +60,8 @@ func NewVentaMineralDetalleBuilder() *ventaMineralDetalleBuilder {
 }
 
 type ventaMineralBuilder struct {
-	factura *documents.FacturaVentaMineral
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaVentaMineral
 }
 
 func (b *ventaMineralBuilder) WithCabecera(req VentaMineralCabecera) *ventaMineralBuilder {
@@ -88,7 +91,7 @@ func (b *ventaMineralBuilder) WithModalidad(tipo int) *ventaMineralBuilder {
 }
 
 func (b *ventaMineralBuilder) Build() VentaMineral {
-	return VentaMineral{models.NewRequestWrapper(b.factura)}
+	return VentaMineral{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type ventaMineralCabeceraBuilder struct {

--- a/pkg/models/invoices/venta_mineral_bcb.go
+++ b/pkg/models/invoices/venta_mineral_bcb.go
@@ -15,6 +15,7 @@ import (
 
 // VentaMineralBCB representa la estructura completa de una factura de Venta de Minerales para el BCB lista para ser procesada.
 type VentaMineralBCB struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaVentaMineralBCB]
 }
 
@@ -31,6 +32,7 @@ type VentaMineralBCBDetalle struct {
 // NewVentaMineralBCBBuilder inicia el proceso de construcción de la factura.
 func NewVentaMineralBCBBuilder() *ventaMineralBCBBuilder {
 	return &ventaMineralBCBBuilder{
+		metadatos: models.NuevosMetadatosFactura(52),
 		factura: &documents.FacturaVentaMineralBCB{
 			XMLName:           xml.Name{Local: "facturaElectronicaVentaMineralBCB"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -60,7 +62,8 @@ func NewVentaMineralBCBDetalleBuilder() *ventaMineralBCBDetalleBuilder {
 }
 
 type ventaMineralBCBBuilder struct {
-	factura *documents.FacturaVentaMineralBCB
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaVentaMineralBCB
 }
 
 func (b *ventaMineralBCBBuilder) WithCabecera(req VentaMineralBCBCabecera) *ventaMineralBCBBuilder {
@@ -92,7 +95,7 @@ func (b *ventaMineralBCBBuilder) WithModalidad(tipo int) *ventaMineralBCBBuilder
 }
 
 func (b *ventaMineralBCBBuilder) Build() VentaMineralBCB {
-	return VentaMineralBCB{models.NewRequestWrapper(b.factura)}
+	return VentaMineralBCB{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type ventaMineralBCBCabeceraBuilder struct {

--- a/pkg/models/invoices/zona_franca.go
+++ b/pkg/models/invoices/zona_franca.go
@@ -15,6 +15,7 @@ import (
 
 // ZonaFranca representa la estructura completa de una factura Zona Franca lista para ser procesada.
 type ZonaFranca struct {
+	models.MetadatosFactura
 	models.RequestWrapper[documents.FacturaZonaFranca]
 }
 
@@ -31,6 +32,7 @@ type ZonaFrancaDetalle struct {
 // NewZonaFrancaBuilder inicia el proceso de construcción de una Factura Zona Franca.
 func NewZonaFrancaBuilder() *zonaFrancaBuilder {
 	return &zonaFrancaBuilder{
+		metadatos: models.NuevosMetadatosFactura(5),
 		factura: &documents.FacturaZonaFranca{
 			XMLName:           xml.Name{Local: "facturaElectronicaZonaFranca"},
 			XmlnsXsi:          "http://www.w3.org/2001/XMLSchema-instance",
@@ -57,7 +59,8 @@ func NewZonaFrancaDetalleBuilder() *zonaFrancaDetalleBuilder {
 }
 
 type zonaFrancaBuilder struct {
-	factura *documents.FacturaZonaFranca
+	metadatos models.MetadatosFactura
+	factura   *documents.FacturaZonaFranca
 }
 
 func (b *zonaFrancaBuilder) WithCabecera(req ZonaFrancaCabecera) *zonaFrancaBuilder {
@@ -87,7 +90,7 @@ func (b *zonaFrancaBuilder) WithModalidad(tipo int) *zonaFrancaBuilder {
 }
 
 func (b *zonaFrancaBuilder) Build() ZonaFranca {
-	return ZonaFranca{models.NewRequestWrapper(b.factura)}
+	return ZonaFranca{RequestWrapper: models.NewRequestWrapper(b.factura), MetadatosFactura: b.metadatos}
 }
 
 type zonaFrancaCabeceraBuilder struct {

--- a/pkg/models/operaciones.go
+++ b/pkg/models/operaciones.go
@@ -237,6 +237,11 @@ type cierreOperacionesSistemaBuilder struct {
 	request *operaciones.CierreOperacionesSistema
 }
 
+func (b *cierreOperacionesSistemaBuilder) WithCodigoModalidad(codigoModalidad int) *cierreOperacionesSistemaBuilder {
+	b.request.SolicitudOperaciones.CodigoModalidad = codigoModalidad
+	return b
+}
+
 func (b *cierreOperacionesSistemaBuilder) WithCodigoSucursal(codigoSucursal int) *cierreOperacionesSistemaBuilder {
 	b.request.SolicitudOperaciones.CodigoSucursal = codigoSucursal
 	return b

--- a/pkg/models/tipo_factura_documento.go
+++ b/pkg/models/tipo_factura_documento.go
@@ -1,0 +1,128 @@
+package models
+
+// Tipos de documento fiscal definidos por el SIAT.
+// Se declaran también en el paquete raíz para mantener su API pública; esta
+// copia evita que models tenga que importar al paquete raíz y crear un ciclo.
+const (
+	TipoFacturaConDerechoCreditoFiscal = iota + 1
+	TipoFacturaSinDerechoCreditoFiscal
+	TipoNotaCreditoDebito
+	TipoBoletoAereo
+)
+
+// DefinicionTipoFactura describe el tipo fiscal predeterminado de un sector
+// implementado por el SDK.
+type DefinicionTipoFactura struct {
+	CodigoDocumentoSector int
+	TipoFacturaDocumento  int
+}
+
+var definicionesTipoFactura = []DefinicionTipoFactura{
+	{1, TipoFacturaConDerechoCreditoFiscal},
+	{2, TipoFacturaConDerechoCreditoFiscal},
+	{3, TipoFacturaSinDerechoCreditoFiscal},
+	{4, TipoFacturaSinDerechoCreditoFiscal},
+	{5, TipoFacturaSinDerechoCreditoFiscal},
+	{6, TipoFacturaSinDerechoCreditoFiscal},
+	{7, TipoFacturaSinDerechoCreditoFiscal},
+	{8, TipoFacturaSinDerechoCreditoFiscal},
+	{9, TipoFacturaSinDerechoCreditoFiscal},
+	{10, TipoFacturaSinDerechoCreditoFiscal},
+	{11, TipoFacturaConDerechoCreditoFiscal},
+	{12, TipoFacturaConDerechoCreditoFiscal},
+	{13, TipoFacturaConDerechoCreditoFiscal},
+	{14, TipoFacturaConDerechoCreditoFiscal},
+	{15, TipoFacturaConDerechoCreditoFiscal},
+	{16, TipoFacturaConDerechoCreditoFiscal},
+	{17, TipoFacturaConDerechoCreditoFiscal},
+	{18, TipoFacturaConDerechoCreditoFiscal},
+	{19, TipoFacturaConDerechoCreditoFiscal},
+	{20, TipoFacturaSinDerechoCreditoFiscal},
+	{21, TipoFacturaConDerechoCreditoFiscal},
+	{22, TipoFacturaConDerechoCreditoFiscal},
+	{23, TipoFacturaConDerechoCreditoFiscal},
+	{24, TipoNotaCreditoDebito},
+	{28, TipoFacturaSinDerechoCreditoFiscal},
+	{29, TipoNotaCreditoDebito},
+	{30, TipoBoletoAereo},
+	{31, TipoFacturaConDerechoCreditoFiscal},
+	{34, TipoFacturaConDerechoCreditoFiscal},
+	{35, TipoFacturaConDerechoCreditoFiscal},
+	{36, TipoFacturaSinDerechoCreditoFiscal},
+	{37, TipoFacturaConDerechoCreditoFiscal},
+	{38, TipoFacturaConDerechoCreditoFiscal},
+	{39, TipoFacturaConDerechoCreditoFiscal},
+	{40, TipoFacturaSinDerechoCreditoFiscal},
+	{41, TipoFacturaConDerechoCreditoFiscal},
+	{42, TipoFacturaSinDerechoCreditoFiscal},
+	{43, TipoFacturaSinDerechoCreditoFiscal},
+	{44, TipoFacturaConDerechoCreditoFiscal},
+	{45, TipoFacturaSinDerechoCreditoFiscal},
+	{46, TipoFacturaSinDerechoCreditoFiscal},
+	{47, TipoNotaCreditoDebito},
+	{48, TipoNotaCreditoDebito},
+	{49, TipoFacturaSinDerechoCreditoFiscal},
+	{50, TipoFacturaSinDerechoCreditoFiscal},
+	{51, TipoFacturaConDerechoCreditoFiscal},
+	{52, TipoFacturaSinDerechoCreditoFiscal},
+	{53, TipoFacturaConDerechoCreditoFiscal},
+	{54, TipoFacturaSinDerechoCreditoFiscal},
+	{55, TipoFacturaConDerechoCreditoFiscal},
+}
+
+var tipoFacturaPorSector = func() map[int]int {
+	tipos := make(map[int]int, len(definicionesTipoFactura))
+	for _, definicion := range definicionesTipoFactura {
+		tipos[definicion.CodigoDocumentoSector] = definicion.TipoFacturaDocumento
+	}
+	return tipos
+}()
+
+// DefinicionesTipoFactura devuelve una copia del catálogo para que los
+// consumidores no puedan alterar las definiciones internas.
+func DefinicionesTipoFactura() []DefinicionTipoFactura {
+	return append([]DefinicionTipoFactura(nil), definicionesTipoFactura...)
+}
+
+// MetadatosFactura contiene la información fiscal que acompaña a un documento
+// durante su preparación y recepción. No se serializa dentro del XML fiscal.
+//
+// El tipo se inicializa desde el catálogo SIAT y puede sobrescribirse en el
+// builder de la factura cuando una integración lo requiera.
+type MetadatosFactura struct {
+	codigoDocumentoSector int
+	tipoFacturaDocumento  int
+}
+
+// NuevosMetadatosFactura crea metadatos con el tipo normativo del sector.
+func NuevosMetadatosFactura(codigoDocumentoSector int) MetadatosFactura {
+	return MetadatosFactura{
+		codigoDocumentoSector: codigoDocumentoSector,
+		tipoFacturaDocumento:  TipoFacturaDocumentoPredeterminado(codigoDocumentoSector),
+	}
+}
+
+// CodigoDocumentoSector identifica el diseño fiscal del documento.
+func (m MetadatosFactura) CodigoDocumentoSector() int { return m.codigoDocumentoSector }
+
+// TipoFacturaDocumento devuelve el tipo fiscal que debe viajar en el CUF y
+// en la solicitud SOAP.
+func (m MetadatosFactura) TipoFacturaDocumento() int { return m.tipoFacturaDocumento }
+
+// WithTipoFacturaDocumento sobrescribe el tipo fiscal predeterminado.
+func (m *MetadatosFactura) WithTipoFacturaDocumento(tipo int) {
+	m.tipoFacturaDocumento = tipo
+}
+
+// TipoFacturaDocumentoPredeterminado devuelve el tipo fiscal normativo para
+// un documento sector. Los sectores desconocidos conservan el tipo 1, que es
+// el valor general de las facturas ordinarias.
+//
+// El valor puede sobrescribirse con WithTipoFacturaDocumento cuando una
+// integración requiera una excepción explícita.
+func TipoFacturaDocumentoPredeterminado(codigoDocumentoSector int) int {
+	if tipo, existe := tipoFacturaPorSector[codigoDocumentoSector]; existe {
+		return tipo
+	}
+	return TipoFacturaConDerechoCreditoFiscal
+}

--- a/pkg/models/tipo_factura_documento_test.go
+++ b/pkg/models/tipo_factura_documento_test.go
@@ -1,0 +1,140 @@
+package models_test
+
+import (
+	"encoding/xml"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ron86i/go-siat/v2"
+	"github.com/ron86i/go-siat/v2/pkg/models"
+)
+
+type documentoFiscalPrueba struct{}
+
+func (documentoFiscalPrueba) TipoFacturaDocumento() int { return siat.TipoNotaCreditoDebito }
+
+func (documentoFiscalPrueba) CodigoDocumentoSector() int { return 24 }
+
+func (documentoFiscalPrueba) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
+	return e.EncodeElement(struct{}{}, xml.StartElement{Name: xml.Name{Local: "notaPrueba"}})
+}
+
+func TestTipoFacturaDocumentoPredeterminado(t *testing.T) {
+	casos := map[int]int{
+		1:  siat.TipoFacturaConDerechoCreditoFiscal,
+		3:  siat.TipoFacturaSinDerechoCreditoFiscal,
+		6:  siat.TipoFacturaSinDerechoCreditoFiscal,
+		8:  siat.TipoFacturaSinDerechoCreditoFiscal,
+		13: siat.TipoFacturaConDerechoCreditoFiscal,
+		24: siat.TipoNotaCreditoDebito,
+		30: siat.TipoBoletoAereo,
+		47: siat.TipoNotaCreditoDebito,
+		52: siat.TipoFacturaSinDerechoCreditoFiscal,
+	}
+	for sector, esperado := range casos {
+		if obtenido := models.TipoFacturaDocumentoPredeterminado(sector); obtenido != esperado {
+			t.Errorf("sector %d: tipo = %d; se esperaba %d", sector, obtenido, esperado)
+		}
+	}
+}
+
+func TestRecepcionesAdoptanMetadatosDelDocumento(t *testing.T) {
+	casos := []struct {
+		nombre string
+		build  func() (any, error)
+	}{
+		{
+			nombre: "factura",
+			build: func() (any, error) {
+				solicitud := models.NewRecepcionFacturaBuilder()
+				if err := solicitud.WithDocumentoFiscal(documentoFiscalPrueba{}, nil); err != nil {
+					return nil, err
+				}
+				return solicitud.Build(), nil
+			},
+		},
+		{
+			nombre: "documento de ajuste",
+			build: func() (any, error) {
+				solicitud := models.NewRecepcionDocumentoAjusteBuilder()
+				if err := solicitud.WithDocumentoFiscal(documentoFiscalPrueba{}, nil); err != nil {
+					return nil, err
+				}
+				return solicitud.Build(), nil
+			},
+		},
+	}
+
+	for _, caso := range casos {
+		t.Run(caso.nombre, func(t *testing.T) {
+			solicitud, err := caso.build()
+			if err != nil {
+				t.Fatalf("serializar documento: %v", err)
+			}
+			raw, err := xml.Marshal(solicitud)
+			if err != nil {
+				t.Fatalf("serializar solicitud: %v", err)
+			}
+			if !strings.Contains(string(raw), "<tipoFacturaDocumento>3</tipoFacturaDocumento>") {
+				t.Fatalf("la solicitud no adoptó el tipo del documento: %s", raw)
+			}
+			if !strings.Contains(string(raw), "<codigoDocumentoSector>24</codigoDocumentoSector>") {
+				t.Fatalf("la solicitud no adoptó el sector del documento: %s", raw)
+			}
+		})
+	}
+}
+
+func TestRecepcionFacturaRespetaMetadatosIndicadosManualmente(t *testing.T) {
+	solicitud := models.NewRecepcionFacturaBuilder().
+		WithCodigoDocumentoSector(99).
+		WithTipoFacturaDocumento(siat.TipoFacturaConDerechoCreditoFiscal)
+	if err := solicitud.WithFactura(documentoFiscalPrueba{}, nil); err != nil {
+		t.Fatalf("serializar documento: %v", err)
+	}
+	raw, err := xml.Marshal(solicitud.Build())
+	if err != nil {
+		t.Fatalf("serializar solicitud: %v", err)
+	}
+	if !strings.Contains(string(raw), "<codigoDocumentoSector>99</codigoDocumentoSector>") {
+		t.Fatalf("la solicitud sobrescribió el sector manual: %s", raw)
+	}
+	if !strings.Contains(string(raw), "<tipoFacturaDocumento>1</tipoFacturaDocumento>") {
+		t.Fatalf("la solicitud sobrescribió el tipo manual: %s", raw)
+	}
+}
+
+func TestRecepcionesExigenFirmaElectronicaCuandoSeSolicita(t *testing.T) {
+	casos := []struct {
+		nombre   string
+		preparar func() error
+	}{
+		{
+			nombre: "factura",
+			preparar: func() error {
+				return models.NewRecepcionFacturaBuilder().
+					WithCodigoModalidad(siat.ModalidadElectronica).
+					WithFirmaElectronicaRequerida().
+					WithDocumentoFiscal(documentoFiscalPrueba{}, nil)
+			},
+		},
+		{
+			nombre: "documento de ajuste",
+			preparar: func() error {
+				return models.NewRecepcionDocumentoAjusteBuilder().
+					WithCodigoModalidad(siat.ModalidadElectronica).
+					WithFirmaElectronicaRequerida().
+					WithDocumentoFiscal(documentoFiscalPrueba{}, nil)
+			},
+		},
+	}
+
+	for _, caso := range casos {
+		t.Run(caso.nombre, func(t *testing.T) {
+			if err := caso.preparar(); !errors.Is(err, models.ErrFirmaElectronicaRequerida) {
+				t.Fatalf("error = %v; se esperaba ErrFirmaElectronicaRequerida", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Resumen

Mejora el soporte de documentos fiscales SIAT y la preparación de solicitudes de recepción.

- Agrega metadatos fiscales (`codigoDocumentoSector` y `tipoFacturaDocumento`) a los builders de sectores soportados.
- Centraliza el catálogo sector → tipo fiscal.
- Propaga automáticamente ambos metadatos al preparar la recepción de facturas y documentos de ajuste.
- Agrega `WithDocumentoFiscal(...)` como alternativa tipada.
- Permite exigir firma XML en modalidad electrónica mediante `WithFirmaElectronicaRequerida()`.
- Amplía las pruebas de operaciones SIAT para consulta, registro y cierre de puntos de venta.
- Ignora las trazas XML locales en `.siat-traces/`.

## Validación

- `go test -count=1 ./pkg/models ./pkg/models/invoices ...`
- `go test -run '^$' ./...`
- `go vet ./...`

## Consideraciones

Las pruebas de operaciones usan credenciales locales desde `.env` y pueden registrar o cerrar puntos de venta en el ambiente configurado. Las trazas XML y archivos de configuración sensible no se incluyen en el repositorio.