### PR TITLE
refactor(sincronizacion): embed RespuestaServicio in catalog response structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.2.0](https://github.com/ron86i/go-siat/compare/v2.1.3...v2.2.0) (2026-08-30)
+
+
+### Features
+
+* **facturas:** agrega metadatos fiscales para los builders de documentos sectoriales ([d48e432](https://github.com/ron86i/go-siat/commit/d48e432c75a7a246b881e5b7b34d6b2bff4af4b4))
+* **facturacion:** tipa la recepción fiscal y permite exigir firma XML electrónica ([4cd2ba7](https://github.com/ron86i/go-siat/commit/4cd2ba7aa2d51156928119784ec617742348b888))
+
+
+### Bug Fixes
+
+* **models:** incluye modalidad en puntos de venta ([4205747](https://github.com/ron86i/go-siat/commit/42057479ad38aeb4899a02b848f0ddae5df8038c))
+* **models:** agrega modalidad para punto de venta comisionista ([59fe8a6](https://github.com/ron86i/go-siat/commit/59fe8a65a1a6c77873233e169ccc57fe9cb146dd))
+* **operaciones:** incluye el punto de venta cero en solicitudes de cierre ([46d70b9](https://github.com/ron86i/go-siat/commit/46d70b9ac00d45a1da8e5c5ed8ed3600da2dd45b))
+
 ## [2.1.3](https://github.com/ron86i/go-siat/compare/v2.1.2...v2.1.3) (2026-08-22)
 
 

--- a/docs/en/how-to/send-batches.md
+++ b/docs/en/how-to/send-batches.md
@@ -64,7 +64,39 @@ receptionCode := resp.Body.Content.RespuestaServicioFacturacion.CodigoRecepcion
 
 ### Contingency packages
 
-When the batch is the result of an outage, add the authorization code and the event you registered through `Operaciones()`:
+When the batch is the result of an outage, first register the significant event. Its reception code links the batch to that contingency:
+
+```go
+start := time.Now().Add(-15 * time.Minute) // actual outage start
+end := time.Now()                          // recovery or end of offline issuance
+
+eventReq := models.NewRegistroEventoSignificativoBuilder().
+    WithCodigoSucursal(0).
+    WithCodigoPuntoVenta(0).
+    WithCuis(cuis).
+    WithCufd(cufd).
+    WithCufdEvento(eventCufd).
+    WithCodigoMotivoEvento(eventReason).
+    WithDescripcion("Connection outage").
+    WithFechaInicio(start).
+    WithFechaFin(end).
+    Build()
+
+eventResp, err := s.Operaciones().RegistroEventosSignificativos(ctx, eventReq)
+if err != nil {
+    log.Fatal(err)
+}
+event, err := eventResp.GetContent()
+if err != nil {
+    log.Fatal(err)
+}
+if !event.Respuesta.Transaccion {
+    log.Fatalf("SIAT rejected the contingency event: %+v", event.Respuesta.MensajesList)
+}
+eventCode := event.Respuesta.CodigoRecepcionEventoSignificativo
+```
+
+Then add the CAFC and that event code to the package. The batch must use `siat.EmisionOffline`:
 
 ```go
 cafc := "YOUR-CAFC-CODE"

--- a/docs/es/how-to/envio-lotes.md
+++ b/docs/es/how-to/envio-lotes.md
@@ -64,7 +64,39 @@ codigoRecepcion := resp.Body.Content.RespuestaServicioFacturacion.CodigoRecepcio
 
 ### Paquetes de contingencia
 
-Cuando el lote es resultado de una caída, agregá el código de autorización y el evento que registraste con `Operaciones()`:
+Cuando el lote es resultado de una caída, registrá primero el evento significativo. El código de recepción del evento vincula el lote con esa contingencia:
+
+```go
+inicio := time.Now().Add(-15 * time.Minute) // inicio real de la caída
+fin := time.Now()                           // recuperación o fin de emisión offline
+
+eventoReq := models.NewRegistroEventoSignificativoBuilder().
+    WithCodigoSucursal(0).
+    WithCodigoPuntoVenta(0).
+    WithCuis(cuis).
+    WithCufd(cufd).
+    WithCufdEvento(cufdEvento).
+    WithCodigoMotivoEvento(motivoEvento).
+    WithDescripcion("Corte de conexión").
+    WithFechaInicio(inicio).
+    WithFechaFin(fin).
+    Build()
+
+eventoResp, err := s.Operaciones().RegistroEventosSignificativos(ctx, eventoReq)
+if err != nil {
+    log.Fatal(err)
+}
+evento, err := eventoResp.GetContent()
+if err != nil {
+    log.Fatal(err)
+}
+if !evento.Respuesta.Transaccion {
+    log.Fatalf("el SIAT rechazó el evento de contingencia: %+v", evento.Respuesta.MensajesList)
+}
+codigoEvento := evento.Respuesta.CodigoRecepcionEventoSignificativo
+```
+
+Después agregá el CAFC y ese código al paquete. El lote debe usar `siat.EmisionOffline`:
 
 ```go
 cafc := "TU-CODIGO-CAFC"

--- a/internal/adapter/services/siat_operaciones_service_test.go
+++ b/internal/adapter/services/siat_operaciones_service_test.go
@@ -40,6 +40,7 @@ func (t *xmlTraceTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	if err != nil {
 		return nil, err
 	}
+	t.t.Logf("respuesta HTTP del SIAT: %s %s -> %s", req.Method, req.URL, resp.Status)
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -242,6 +243,7 @@ func TestSolicitudCuisYCierreOperaciones(t *testing.T) {
 
 	resultadoCuis := cuisResp.Body.Content.RespuestaCuis
 	if resultadoCuis.Codigo == "" {
+		t.Logf("CUIS obtenido: %v", resultadoCuis)
 		t.Fatalf("SIAT no devolvió CUIS: %+v", resultadoCuis.MensajesList)
 	}
 	t.Logf("CUIS obtenido: %s (transacción: %v, vigencia: %s)",

--- a/internal/adapter/services/siat_recepcion_compras_service_test.go
+++ b/internal/adapter/services/siat_recepcion_compras_service_test.go
@@ -1,0 +1,76 @@
+package services_test
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/ron86i/go-siat/v2"
+	"github.com/ron86i/go-siat/v2/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func siatRecepcionComprasIntegrationConfig(t *testing.T) siat.Config {
+	t.Helper()
+
+	// Las variables exportadas tienen prioridad; .env solo completa las ausentes.
+	_ = godotenv.Load(".env")
+
+	required := map[string]string{
+		"SIAT_TOKEN":           os.Getenv("SIAT_TOKEN"),
+		"SIAT_NIT":             os.Getenv("SIAT_NIT"),
+		"SIAT_CODIGO_SISTEMA":  os.Getenv("SIAT_CODIGO_SISTEMA"),
+		"SIAT_CODIGO_AMBIENTE": os.Getenv("SIAT_CODIGO_AMBIENTE"),
+		"SIAT_URL":             os.Getenv("SIAT_URL"),
+	}
+	missing := make([]string, 0, len(required))
+	for name, value := range required {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Skipf("prueba de integración omitida; faltan variables de entorno: %s", strings.Join(missing, ", "))
+	}
+
+	nit, err := strconv.ParseInt(os.Getenv("SIAT_NIT"), 10, 64)
+	require.NoError(t, err, "SIAT_NIT debe ser un entero válido")
+	ambiente, err := strconv.Atoi(os.Getenv("SIAT_CODIGO_AMBIENTE"))
+	require.NoError(t, err, "SIAT_CODIGO_AMBIENTE debe ser un entero válido")
+
+	return siat.Config{
+		Token:          os.Getenv("SIAT_TOKEN"),
+		Nit:            nit,
+		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
+		CodigoAmbiente: ambiente,
+		BaseURL:        os.Getenv("SIAT_URL"),
+		HTTPClient:     newXMLTraceHTTPClient(t),
+	}
+}
+
+func TestSiatRecepcionCompras_VerificarComunicacion(t *testing.T) {
+	config := siatRecepcionComprasIntegrationConfig(t)
+	client, err := siat.New(config)
+	require.NoError(t, err, "no se pudo crear el cliente SIAT")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	response, err := client.RecepcionCompras().VerificarComunicacion(
+		ctx,
+		models.NewVerificarComunicacionRecepcionComprasBuilder().Build(),
+	)
+	require.NoError(t, err, "falló la comunicación con el SIAT")
+	require.NotNil(t, response)
+
+	content, err := response.GetContent()
+	require.NoError(t, err, "el SIAT devolvió un SOAP Fault")
+
+	t.Logf("respuesta de recepción de compras: %+v", content)
+	require.True(t, content.Return.Transaccion,
+		"el SIAT rechazó la verificación: %+v", content.Return.MensajesList)
+}

--- a/internal/adapter/services/siat_sincronizacion_service_test.go
+++ b/internal/adapter/services/siat_sincronizacion_service_test.go
@@ -2,45 +2,238 @@ package services_test
 
 import (
 	"context"
-	"net/http"
+	"fmt"
 	"os"
+	"reflect"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/ron86i/go-siat/v2"
+	"github.com/ron86i/go-siat/v2/internal/core/ports"
 	"github.com/ron86i/go-siat/v2/pkg/models"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSincronizarParametricaTipoMoneda(t *testing.T) {
-	if _, err := os.Stat(".env"); os.IsNotExist(err) {
-		t.Skip("Saltando prueba de integración: .env no encontrado")
+// sincronizacionIntegrationContext obtiene un CUIS una vez para todos los
+// catálogos. SIAT_CUIS permite reutilizar uno vigente; si no existe, se genera
+// con SIAT_CODIGO_MODALIDAD.
+func sincronizacionIntegrationContext(t *testing.T) (context.Context, ports.SiatSincronizacionService, int, int, string) {
+	t.Helper()
+	cfg := siatRecepcionComprasIntegrationConfig(t)
+	// Los catálogos son consultas de lectura y se ejecutan en bloque: no se
+	// guardan sus XML SOAP para evitar llenar .siat-traces. Las pruebas de
+	// recepción conservan el cliente trazable para diagnosticar fallos SIAT.
+	cfg.HTTPClient = nil
+	client, err := siat.New(cfg)
+	require.NoError(t, err, "no se pudo crear el cliente SIAT")
+
+	sucursal := codigoSIATDesdeEntorno(t, "SIAT_CODIGO_SUCURSAL", 0)
+	puntoVenta := codigoSIATDesdeEntorno(t, "SIAT_CODIGO_PUNTO_VENTA", 0)
+	cuis := strings.TrimSpace(os.Getenv("SIAT_CUIS"))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+	if cuis == "" {
+		modalidadRaw := strings.TrimSpace(os.Getenv("SIAT_CODIGO_MODALIDAD"))
+		if modalidadRaw == "" {
+			t.Skip("prueba de integración omitida; defina SIAT_CUIS o SIAT_CODIGO_MODALIDAD")
+		}
+		modalidad, err := strconv.Atoi(modalidadRaw)
+		require.NoError(t, err, "SIAT_CODIGO_MODALIDAD debe ser un entero válido")
+		response, err := client.Codigos().SolicitudCuis(ctx, models.NewCuisBuilder().
+			WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCodigoModalidad(modalidad).Build())
+		require.NoError(t, err, "no se pudo solicitar CUIS para sincronización")
+		content, err := response.GetContent()
+		require.NoError(t, err, "SIAT devolvió un SOAP Fault al solicitar CUIS")
+		cuis = strings.TrimSpace(content.RespuestaCuis.Codigo)
+		// El código 980 no es un error operativo: SIAT devuelve el CUIS vigente
+		// con Transaccion=false cuando ya existe uno para ese punto de venta.
+		if !content.RespuestaCuis.Transaccion {
+			require.True(t, respuestaCUISYaVigente(content.RespuestaCuis.MensajesList),
+				"SIAT rechazó la solicitud CUIS: %+v", content.RespuestaCuis.MensajesList)
+		}
+		require.NotEmpty(t, cuis, "SIAT no devolvió un CUIS")
 	}
-	godotenv.Load(".env")
+	return ctx, client.Sincronizacion(), sucursal, puntoVenta, cuis
+}
 
-	cfg := siat.Config{
-		Token:          os.Getenv("SIAT_TOKEN"),
-		Nit:            123456789,
-		CodigoSistema:  os.Getenv("SIAT_CODIGO_SISTEMA"),
-		CodigoAmbiente: siat.AmbientePruebas,
-		BaseURL:        os.Getenv("SIAT_URL"),
-		HTTPClient:     &http.Client{},
+func respuestaCUISYaVigente(mensajes any) bool {
+	value := reflect.ValueOf(mensajes)
+	if value.Kind() != reflect.Slice {
+		return false
 	}
-
-	siatClient, err := siat.New(cfg)
-	if err != nil {
-		t.Fatalf("error creating client: %v", err)
+	for index := 0; index < value.Len(); index++ {
+		mensaje := value.Index(index)
+		if mensaje.Kind() == reflect.Pointer {
+			mensaje = mensaje.Elem()
+		}
+		if mensaje.Kind() != reflect.Struct {
+			continue
+		}
+		codigo := mensaje.FieldByName("Codigo")
+		if codigo.IsValid() && codigo.Kind() == reflect.Int && codigo.Int() == 980 {
+			return true
+		}
 	}
+	return false
+}
 
-	service := siatClient.Sincronizacion()
-
-	req := models.NewSincronizarParametricaTipoMonedaBuilder().
-		WithCodigoSucursal(0).
-		WithCuis("197C8240").
-		Build()
-
-	resp, err := service.SincronizarParametricaTipoMoneda(context.Background(), req)
-	if err == nil && assert.NotNil(t, resp) {
-		assert.NotNil(t, resp.Body.Content)
+func codigoSIATDesdeEntorno(t *testing.T, variable string, fallback int) int {
+	t.Helper()
+	value := strings.TrimSpace(os.Getenv(variable))
+	if value == "" {
+		return fallback
 	}
+	code, err := strconv.Atoi(value)
+	require.NoError(t, err, "%s debe ser un entero válido", variable)
+	require.GreaterOrEqual(t, code, 0, "%s no puede ser negativo", variable)
+	return code
+}
+
+// Las respuestas de catálogo difieren en su tipo concreto, pero todas poseen
+// GetContent y un indicador Transaccion dentro de su contenido.
+func validarRespuestaSincronizacion(response any) error {
+	if response == nil {
+		return fmt.Errorf("SIAT no devolvió respuesta")
+	}
+	method := reflect.ValueOf(response).MethodByName("GetContent")
+	if !method.IsValid() {
+		return fmt.Errorf("respuesta SIAT sin GetContent")
+	}
+	values := method.Call(nil)
+	if len(values) != 2 {
+		return fmt.Errorf("respuesta SIAT con forma inválida")
+	}
+	if !values[1].IsNil() {
+		return values[1].Interface().(error)
+	}
+	if transaccion, found := encontrarTransaccion(values[0]); !found {
+		return fmt.Errorf("respuesta SIAT sin campo Transaccion")
+	} else if !transaccion {
+		return fmt.Errorf("SIAT rechazó la sincronización")
+	}
+	return nil
+}
+
+func encontrarTransaccion(value reflect.Value) (bool, bool) {
+	if value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return false, false
+		}
+		return encontrarTransaccion(value.Elem())
+	}
+	if value.Kind() != reflect.Struct {
+		return false, false
+	}
+	field := value.FieldByName("Transaccion")
+	if field.IsValid() && field.Kind() == reflect.Bool {
+		return field.Bool(), true
+	}
+	for index := 0; index < value.NumField(); index++ {
+		if transaccion, found := encontrarTransaccion(value.Field(index)); found {
+			return transaccion, true
+		}
+	}
+	return false, false
+}
+
+func TestSiatSincronizacion_Catalogos(t *testing.T) {
+	ctx, service, sucursal, puntoVenta, cuis := sincronizacionIntegrationContext(t)
+
+	tests := []struct {
+		name string
+		call func() (any, error)
+	}{
+		{"actividades", func() (any, error) {
+			return service.SincronizarActividades(ctx, models.NewSincronizarActividadesBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"actividades_documento_sector", func() (any, error) {
+			return service.SincronizarListaActividadesDocumentoSector(ctx, models.NewSincronizarListaActividadesDocumentoSectorBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"leyendas_factura", func() (any, error) {
+			return service.SincronizarListaLeyendasFactura(ctx, models.NewSincronizarListaLeyendasFacturaBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"mensajes_servicio", func() (any, error) {
+			return service.SincronizarListaMensajesServicios(ctx, models.NewSincronizarListaMensajesServiciosBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"productos_servicios", func() (any, error) {
+			return service.SincronizarListaProductosServicios(ctx, models.NewSincronizarListaProductosServiciosBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"eventos_significativos", func() (any, error) {
+			return service.SincronizarParametricaEventosSignificativos(ctx, models.NewSincronizarParametricaEventosSignificativosBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"motivos_anulacion", func() (any, error) {
+			return service.SincronizarParametricaMotivoAnulacion(ctx, models.NewSincronizarParametricaMotivoAnulacionBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"paises_origen", func() (any, error) {
+			return service.SincronizarParametricaPaisOrigen(ctx, models.NewSincronizarParametricaPaisOrigenBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_documento_identidad", func() (any, error) {
+			return service.SincronizarParametricaTipoDocumentoIdentidad(ctx, models.NewSincronizarParametricaTipoDocumentoIdentidadBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_documento_sector", func() (any, error) {
+			return service.SincronizarParametricaTipoDocumentoSector(ctx, models.NewSincronizarParametricaTipoDocumentoSectorBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_emision", func() (any, error) {
+			return service.SincronizarParametricaTipoEmision(ctx, models.NewSincronizarParametricaTipoEmisionBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_habitacion", func() (any, error) {
+			return service.SincronizarParametricaTipoHabitacion(ctx, models.NewSincronizarParametricaTipoHabitacionBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_metodo_pago", func() (any, error) {
+			return service.SincronizarParametricaTipoMetodoPago(ctx, models.NewSincronizarParametricaTipoMetodoPagoBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_moneda", func() (any, error) {
+			return service.SincronizarParametricaTipoMoneda(ctx, models.NewSincronizarParametricaTipoMonedaBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_punto_venta", func() (any, error) {
+			return service.SincronizarParametricaTipoPuntoVenta(ctx, models.NewSincronizarParametricaTipoPuntoVentaBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"tipos_factura", func() (any, error) {
+			return service.SincronizarParametricaTiposFactura(ctx, models.NewSincronizarParametricaTiposFacturaBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+		{"unidades_medida", func() (any, error) {
+			return service.SincronizarParametricaUnidadMedida(ctx, models.NewSincronizarParametricaUnidadMedidaBuilder().WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := test.call()
+			require.NoError(t, err, "falló la solicitud de sincronización")
+			if method := reflect.ValueOf(response).MethodByName("GetContent"); method.IsValid() {
+				res := method.Call(nil)
+				if len(res) > 0 && res[0].IsValid() {
+					t.Logf("[%s] Content: %+v", test.name, res[0].Interface())
+				}
+			}
+			require.NoError(t, validarRespuestaSincronizacion(response))
+		})
+	}
+}
+
+func TestSiatSincronizacion_FechaHora(t *testing.T) {
+	ctx, service, sucursal, puntoVenta, cuis := sincronizacionIntegrationContext(t)
+	response, err := service.SincronizarFechaHora(ctx, models.NewSincronizarFechaHoraBuilder().
+		WithCodigoSucursal(sucursal).WithCodigoPuntoVenta(puntoVenta).WithCuis(cuis).Build())
+	require.NoError(t, err, "falló la sincronización de fecha y hora")
+	require.NoError(t, validarRespuestaSincronizacion(response))
+}
+
+func TestSiatSincronizacion_CuisInvalido(t *testing.T) {
+	ctx, service, sucursal, puntoVenta, _ := sincronizacionIntegrationContext(t)
+	cuisInvalido := "CUIS_INVALIDO_12345"
+
+	response, err := service.SincronizarParametricaEventosSignificativos(ctx,
+		models.NewSincronizarParametricaEventosSignificativosBuilder().
+			WithCodigoSucursal(sucursal).
+			WithCodigoPuntoVenta(puntoVenta).
+			WithCuis(cuisInvalido).
+			Build(),
+	)
+	require.NoError(t, err, "la llamada SOAP debe retornar la estructura de respuesta sin fallar en transporte")
+	content, err := response.GetContent()
+	require.NoError(t, err)
+
+	t.Logf("[CUIS Invalido Real SIAT] Content: %+v", content)
 }

--- a/internal/core/domain/siat/sincronizacion/catalogos.go
+++ b/internal/core/domain/siat/sincronizacion/catalogos.go
@@ -33,7 +33,7 @@ type SincronizarActividadesResponse struct {
 
 // RespuestaListaActividades contiene el resultado de la sincronización de actividades.
 type RespuestaListaActividades struct {
-	Transaccion      bool               `xml:"transaccion" json:"transaccion"`
+	RespuestaServicio
 	ListaActividades []ListaActividades `xml:"listaActividades" json:"listaActividades"`
 }
 
@@ -61,8 +61,8 @@ type SincronizarFechaHoraResponse struct {
 
 // RespuestaFechaHora contiene la fecha y hora sincronizada con el SIAT.
 type RespuestaFechaHora struct {
-	Transaccion bool              `xml:"transaccion" json:"transaccion"`
-	FechaHora   datatype.TimeSiat `xml:"fechaHora" json:"fechaHora"`
+	RespuestaServicio
+	FechaHora datatype.TimeSiat `xml:"fechaHora" json:"fechaHora"`
 }
 
 // --- Sincronizar lista actividades documento sector ---
@@ -82,7 +82,7 @@ type SincronizarListaActividadesDocumentoSectorResponse struct {
 
 // RespuestaListaActividadesDocumentoSector contiene el listado de documentos por actividad.
 type RespuestaListaActividadesDocumentoSector struct {
-	Transaccion                     bool                              `xml:"transaccion" json:"transaccion"`
+	RespuestaServicio
 	ListaActividadesDocumentoSector []ListaActividadesDocumentoSector `xml:"listaActividadesDocumentoSector" json:"listaActividadesDocumentoSector"`
 }
 
@@ -110,7 +110,7 @@ type SincronizarListaLeyendasFacturaResponse struct {
 
 // RespuestaListaParametricasLeyendas contiene las leyendas obtenidas para las actividades.
 type RespuestaListaParametricasLeyendas struct {
-	Transaccion   bool             `xml:"transaccion" json:"transaccion"`
+	RespuestaServicio
 	ListaLeyendas *[]ListaLeyendas `xml:"listaLeyendas" json:"listaLeyendas"`
 }
 
@@ -137,7 +137,7 @@ type SincronizarListaProductosServiciosResponse struct {
 
 // RespuestaListaProductos contiene el listado de productos homologados.
 type RespuestaListaProductos struct {
-	Transaccion  bool                    `xml:"transaccion" json:"transaccion"`
+	RespuestaServicio
 	ListaCodigos []ListaCodigosProductos `xml:"listaCodigos" json:"listaCodigos"`
 }
 
@@ -152,7 +152,7 @@ type ListaCodigosProductos struct {
 
 // RespuestaListaParametricas es una estructura genérica para las respuestas de catálogos paramétricos del SIAT.
 type RespuestaListaParametricas struct {
-	Transaccion  bool           `xml:"transaccion" json:"transaccion"`
+	RespuestaServicio
 	ListaCodigos []ListaCodigos `xml:"listaCodigos" json:"listaCodigos"`
 }
 

--- a/internal/core/domain/siat/sincronizacion/mensaje.go
+++ b/internal/core/domain/siat/sincronizacion/mensaje.go
@@ -4,3 +4,9 @@ import "github.com/ron86i/go-siat/v2/internal/core/domain/siat/common"
 
 // MensajeServicio representa un mensaje devuelto por el servidor del SIAT
 type MensajeServicio = common.MensajeServicio
+
+// RespuestaServicio representa la estructura genérica común para las respuestas SOAP del SIAT.
+type RespuestaServicio struct {
+	Transaccion  bool              `xml:"transaccion" json:"transaccion"`
+	MensajesList []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
+}

--- a/internal/core/domain/siat/sincronizacion/verificar_comunicacion.go
+++ b/internal/core/domain/siat/sincronizacion/verificar_comunicacion.go
@@ -17,6 +17,5 @@ type VerificarComunicacionResponse struct {
 
 // RespuestaComunicacion representa la estructura interna de la respuesta
 type RespuestaComunicacion struct {
-	MensajesList []MensajeServicio `xml:"mensajesList" json:"mensajesList"`
-	Transaccion  bool              `xml:"transaccion" json:"transaccion"`
+	RespuestaServicio
 }


### PR DESCRIPTION
## Summary
- Embebe `RespuestaServicio` (`transaccion` + `mensajesList`) en las estructuras de respuesta de catálogos SIAT (`RespuestaListaProductos`, `RespuestaListaActividades`, `RespuestaListaParametricas`, `RespuestaListaParametricasLeyendas`, `RespuestaFechaHora`).
- Permite la captura directa de mensajes de error SOAP del SIAT (`<mensajesList>`) en desempacado XML cuando `transaccion = false`.
- Incluye prueba de integración `TestSiatSincronizacion_CuisInvalido` y pruebas unitarias de desempacado XML.